### PR TITLE
[FEAT] Resolve client IP from forwarded header behind proxy

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -157,7 +157,8 @@ Enable `ForwardedIp` to read the originating client IP from a proxy header inste
       "Enabled": true,
       "ForwardedIp": {
         "Enabled": true,
-        "HeaderName": "cf-connecting-ip"
+        "HeaderName": "cf-connecting-ip",
+        "TrustedHosts": ["www.example.com"]
       },
       "Rules": {
         "IpWhitelist": ["192.168.1.100", "10.0.0.0/24"]
@@ -171,10 +172,13 @@ Enable `ForwardedIp` to read the originating client IP from a proxy header inste
 |--------|-------------|---------|
 | `Enabled` | When `true`, read the client IP from `HeaderName` before falling back to the connection IP | `false` |
 | `HeaderName` | Header carrying the originating client IP. If it holds a comma-separated list, the first entry is used | `"cf-connecting-ip"` |
+| `TrustedHosts` | Optional hostnames (case-insensitive, exact match, no port) the header is trusted for. When empty, the header is trusted on all hosts | Empty (all hosts) |
 
 `HeaderName` is generic, so other providers work too — e.g. `"X-Azure-ClientIP"` for Azure Front Door.
 
 > ⚠️ **Security:** Only enable `ForwardedIp` when your application is guaranteed to receive traffic **exclusively** through the named trusted proxy. Request headers are client-controlled, so if traffic can reach the origin directly, a client could spoof the header to appear as a whitelisted IP and bypass protection. This is why the feature is opt-in and off by default. For the same reason, prefer a proxy-set header such as `cf-connecting-ip` over the client-appendable `X-Forwarded-For`.
+>
+> **Umbraco Cloud (and similar):** your site is reachable both via the proxied custom domain **and** the raw project domain (e.g. `myproject.umbraco.io`), which is **not** fronted by Cloudflare. Without scoping, a request to the raw domain could carry a spoofed `cf-connecting-ip` and bypass the whitelist. Set `TrustedHosts` to your custom domain(s) so the header is honoured only there and ignored on the raw domain.
 
 ### Header Authorisation
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -85,6 +85,7 @@ app.UseMiddleware<RequestProtectMiddleware>();
 | `Rules` | Authentication rules configuration (see below) | Empty |
 | `Response` | Response configuration for unauthorized requests (see below) | 400 status |
 | `Cookie` | Cookie configuration for auth cookie behavior (see below) | 30-min persistent |
+| `ForwardedIp` | Resolve the client IP from a forwarded header when behind a trusted proxy (see below) | Disabled |
 
 ### Authentication Rules
 
@@ -141,6 +142,39 @@ This configuration will require query string authentication for all routes start
 ```
 
 This configuration will only allow requests from the specified IP addresses.
+
+### Client IP Behind a Reverse Proxy / CDN
+
+By default the client IP is read from the transport connection (`RemoteIpAddress`). When your app is hosted behind a reverse proxy or CDN — for example **Cloudflare** or **Umbraco Cloud** — that connection IP is the *proxy's* address, not the visitor's, so IP whitelisting will never match the real client.
+
+Enable `ForwardedIp` to read the originating client IP from a proxy header instead, falling back to the connection IP when the header is absent or unparseable:
+
+```json
+{
+  "MYA":
+  {
+    "RP": {
+      "Enabled": true,
+      "ForwardedIp": {
+        "Enabled": true,
+        "HeaderName": "cf-connecting-ip"
+      },
+      "Rules": {
+        "IpWhitelist": ["192.168.1.100", "10.0.0.0/24"]
+      }
+    }
+  }
+}
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `Enabled` | When `true`, read the client IP from `HeaderName` before falling back to the connection IP | `false` |
+| `HeaderName` | Header carrying the originating client IP. If it holds a comma-separated list, the first entry is used | `"cf-connecting-ip"` |
+
+`HeaderName` is generic, so other providers work too — e.g. `"X-Azure-ClientIP"` for Azure Front Door.
+
+> ⚠️ **Security:** Only enable `ForwardedIp` when your application is guaranteed to receive traffic **exclusively** through the named trusted proxy. Request headers are client-controlled, so if traffic can reach the origin directly, a client could spoof the header to appear as a whitelisted IP and bypass protection. This is why the feature is opt-in and off by default. For the same reason, prefer a proxy-set header such as `cf-connecting-ip` over the client-appendable `X-Forwarded-For`.
 
 ### Header Authorisation
 

--- a/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_CustomHeader_Returns_200.verified.txt
+++ b/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_CustomHeader_Returns_200.verified.txt
@@ -1,0 +1,19 @@
+﻿{
+  Version: 1.1,
+  Content: {
+    Headers: []
+  },
+  StatusCode: OK,
+  ReasonPhrase: OK,
+  Headers: [],
+  TrailingHeaders: [],
+  RequestMessage: {
+    Version: 1.1,
+    Method: {
+      Method: GET
+    },
+    RequestUri: https://localhost/,
+    Headers: []
+  },
+  IsSuccessStatusCode: true
+}

--- a/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_Disabled_Header_Ignored_Returns_400.verified.txt
+++ b/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_Disabled_Header_Ignored_Returns_400.verified.txt
@@ -1,0 +1,19 @@
+﻿{
+  Version: 1.1,
+  Content: {
+    Headers: []
+  },
+  StatusCode: BadRequest,
+  ReasonPhrase: Bad Request,
+  Headers: [],
+  TrailingHeaders: [],
+  RequestMessage: {
+    Version: 1.1,
+    Method: {
+      Method: GET
+    },
+    RequestUri: https://localhost/,
+    Headers: []
+  },
+  IsSuccessStatusCode: false
+}

--- a/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_Enabled_Header_Absent_FallsBack_Returns_200.verified.txt
+++ b/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_Enabled_Header_Absent_FallsBack_Returns_200.verified.txt
@@ -1,0 +1,19 @@
+﻿{
+  Version: 1.1,
+  Content: {
+    Headers: []
+  },
+  StatusCode: OK,
+  ReasonPhrase: OK,
+  Headers: [],
+  TrailingHeaders: [],
+  RequestMessage: {
+    Version: 1.1,
+    Method: {
+      Method: GET
+    },
+    RequestUri: https://localhost/,
+    Headers: []
+  },
+  IsSuccessStatusCode: true
+}

--- a/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_Enabled_Invalid_Header_FallsBack_Returns_400.verified.txt
+++ b/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_Enabled_Invalid_Header_FallsBack_Returns_400.verified.txt
@@ -1,0 +1,19 @@
+﻿{
+  Version: 1.1,
+  Content: {
+    Headers: []
+  },
+  StatusCode: BadRequest,
+  ReasonPhrase: Bad Request,
+  Headers: [],
+  TrailingHeaders: [],
+  RequestMessage: {
+    Version: 1.1,
+    Method: {
+      Method: GET
+    },
+    RequestUri: https://localhost/,
+    Headers: []
+  },
+  IsSuccessStatusCode: false
+}

--- a/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_Enabled_NotWhitelisted_Returns_400.verified.txt
+++ b/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_Enabled_NotWhitelisted_Returns_400.verified.txt
@@ -1,0 +1,19 @@
+﻿{
+  Version: 1.1,
+  Content: {
+    Headers: []
+  },
+  StatusCode: BadRequest,
+  ReasonPhrase: Bad Request,
+  Headers: [],
+  TrailingHeaders: [],
+  RequestMessage: {
+    Version: 1.1,
+    Method: {
+      Method: GET
+    },
+    RequestUri: https://localhost/,
+    Headers: []
+  },
+  IsSuccessStatusCode: false
+}

--- a/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_Enabled_Whitelisted_Returns_200.verified.txt
+++ b/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_Enabled_Whitelisted_Returns_200.verified.txt
@@ -1,0 +1,19 @@
+﻿{
+  Version: 1.1,
+  Content: {
+    Headers: []
+  },
+  StatusCode: OK,
+  ReasonPhrase: OK,
+  Headers: [],
+  TrailingHeaders: [],
+  RequestMessage: {
+    Version: 1.1,
+    Method: {
+      Method: GET
+    },
+    RequestUri: https://localhost/,
+    Headers: []
+  },
+  IsSuccessStatusCode: true
+}

--- a/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_TrustedHost_Match_UsesHeader_Returns_200.verified.txt
+++ b/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_TrustedHost_Match_UsesHeader_Returns_200.verified.txt
@@ -1,0 +1,19 @@
+﻿{
+  Version: 1.1,
+  Content: {
+    Headers: []
+  },
+  StatusCode: OK,
+  ReasonPhrase: OK,
+  Headers: [],
+  TrailingHeaders: [],
+  RequestMessage: {
+    Version: 1.1,
+    Method: {
+      Method: GET
+    },
+    RequestUri: https://www.example.com/,
+    Headers: []
+  },
+  IsSuccessStatusCode: true
+}

--- a/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_UntrustedHost_IgnoresHeader_Returns_400.verified.txt
+++ b/src/MYA.RequestProtect.Test/MiddlewareTests.ForwardedIp_UntrustedHost_IgnoresHeader_Returns_400.verified.txt
@@ -1,0 +1,19 @@
+﻿{
+  Version: 1.1,
+  Content: {
+    Headers: []
+  },
+  StatusCode: BadRequest,
+  ReasonPhrase: Bad Request,
+  Headers: [],
+  TrailingHeaders: [],
+  RequestMessage: {
+    Version: 1.1,
+    Method: {
+      Method: GET
+    },
+    RequestUri: https://myproject.umbraco.io/,
+    Headers: []
+  },
+  IsSuccessStatusCode: false
+}

--- a/src/MYA.RequestProtect.Test/MiddlewareTests.cs
+++ b/src/MYA.RequestProtect.Test/MiddlewareTests.cs
@@ -88,6 +88,22 @@ public class MiddlewareTests
     }
 
     [Theory()]
+    [ClassData(typeof(OptionsWithForwardedIpTestCases))]
+    public async Task Auth_ForwardedIp_Tests(RequestProtectOptions options, string url, string? forwardedHeaderName, string? forwardedHeaderValue)
+    {
+        // Arrange
+        using var server = Host.CreateTestServer(logger, options, forwardedHeaderName: forwardedHeaderName, forwardedHeaderValue: forwardedHeaderValue);
+        var client = server.CreateClient();
+
+        // Act
+        var response = await client.GetAsync(url, TestContext.Current.CancellationToken);
+
+        // Assert
+        await Verify(response)
+            .UseFileName(TestContext.Current.Test.FileSafeTestName());
+    }
+
+    [Theory()]
     [ClassData(typeof(OptionsWithHeaderTestCases))]
     public async Task Auth_HeaderRule_Tests(RequestProtectOptions options, string url)
     {

--- a/src/MYA.RequestProtect.Test/MiddlewareTests.cs
+++ b/src/MYA.RequestProtect.Test/MiddlewareTests.cs
@@ -89,10 +89,11 @@ public class MiddlewareTests
 
     [Theory()]
     [ClassData(typeof(OptionsWithForwardedIpTestCases))]
-    public async Task Auth_ForwardedIp_Tests(RequestProtectOptions options, string url, string? forwardedHeaderName, string? forwardedHeaderValue)
+    public async Task Auth_ForwardedIp_Tests(RequestProtectOptions options, string url, string? forwardedHeaderName, string? forwardedHeaderValue, string? host)
     {
         // Arrange
-        using var server = Host.CreateTestServer(logger, options, forwardedHeaderName: forwardedHeaderName, forwardedHeaderValue: forwardedHeaderValue);
+        var baseAddress = string.IsNullOrWhiteSpace(host) ? null : new Uri($"https://{host}");
+        using var server = Host.CreateTestServer(logger, options, baseAddress: baseAddress, forwardedHeaderName: forwardedHeaderName, forwardedHeaderValue: forwardedHeaderValue);
         var client = server.CreateClient();
 
         // Act

--- a/src/MYA.RequestProtect.Test/Setup/Host.cs
+++ b/src/MYA.RequestProtect.Test/Setup/Host.cs
@@ -22,7 +22,8 @@ internal static class Host
         ILogger logger,
         RequestProtectOptions? options = null,
         Uri? baseAddress = null,
-        string? webRootPath = null, string? remoteIp = null)
+        string? webRootPath = null, string? remoteIp = null,
+        string? forwardedHeaderName = null, string? forwardedHeaderValue = null)
     {
         var builder = new WebHostBuilder()
             .UseTestServer();
@@ -67,6 +68,12 @@ internal static class Host
                 app.Use(async (context, next) =>
                 {
                     context.Connection.RemoteIpAddress = IPAddress.Parse(string.IsNullOrWhiteSpace(remoteIp) ? DefaultRemoteIP : remoteIp);
+
+                    if (!string.IsNullOrWhiteSpace(forwardedHeaderName) && forwardedHeaderValue is not null)
+                    {
+                        context.Request.Headers[forwardedHeaderName] = forwardedHeaderValue;
+                    }
+
                     context.Request.Headers["singleHeader"] = "singleHeader";
                     context.Request.Headers["wildHeader"] = "wildHeader";
                     context.Request.Headers["headerTwo"] = "2";

--- a/src/MYA.RequestProtect.Test/TestCases/OptionsWithForwardedIpTestCases.cs
+++ b/src/MYA.RequestProtect.Test/TestCases/OptionsWithForwardedIpTestCases.cs
@@ -6,42 +6,52 @@ namespace MYA.RequestProtect.Tests.TestCases;
 /// <summary>
 /// Test cases covering client IP resolution from a forwarded header (e.g. Cloudflare's
 /// "cf-connecting-ip") when hosted behind a trusted reverse proxy. Columns are
-/// (options, url, forwardedHeaderName, forwardedHeaderValue). The test harness always sets the
-/// transport connection IP to <see cref="Setup.Host.DefaultRemoteIP"/>.
+/// (options, url, forwardedHeaderName, forwardedHeaderValue, host). The test harness always sets the
+/// transport connection IP to <see cref="Setup.Host.DefaultRemoteIP"/>; a null host uses the default.
 /// </summary>
-public class OptionsWithForwardedIpTestCases : IEnumerable<TheoryDataRow<RequestProtectOptions, string, string?, string?>>
+public class OptionsWithForwardedIpTestCases : IEnumerable<TheoryDataRow<RequestProtectOptions, string, string?, string?, string?>>
 {
-    public IEnumerator<TheoryDataRow<RequestProtectOptions, string, string?, string?>> GetEnumerator()
+    public IEnumerator<TheoryDataRow<RequestProtectOptions, string, string?, string?, string?>> GetEnumerator()
     {
         // Header enabled + carries a whitelisted IP -> allowed, even though the connection IP is not whitelisted.
-        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?>(
-            ForwardedIpEnabled, "/", "cf-connecting-ip", "4.180.158.195")
+        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?, string?>(
+            ForwardedIpEnabled, "/", "cf-connecting-ip", "4.180.158.195", null)
         { TestDisplayName = "ForwardedIp_Enabled_Whitelisted_Returns_200" };
 
         // Header enabled + carries a non-whitelisted IP -> blocked.
-        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?>(
-            ForwardedIpEnabled, "/", "cf-connecting-ip", "8.8.8.8")
+        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?, string?>(
+            ForwardedIpEnabled, "/", "cf-connecting-ip", "8.8.8.8", null)
         { TestDisplayName = "ForwardedIp_Enabled_NotWhitelisted_Returns_400" };
 
         // Header disabled but a spoofed whitelisted IP is sent -> ignored, connection IP used -> blocked.
-        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?>(
-            ForwardedIpDisabled, "/", "cf-connecting-ip", "4.180.158.195")
+        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?, string?>(
+            ForwardedIpDisabled, "/", "cf-connecting-ip", "4.180.158.195", null)
         { TestDisplayName = "ForwardedIp_Disabled_Header_Ignored_Returns_400" };
 
         // Header enabled but absent -> falls back to the (whitelisted) connection IP -> allowed.
-        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?>(
-            ForwardedIpEnabledConnectionWhitelisted, "/", null, null)
+        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?, string?>(
+            ForwardedIpEnabledConnectionWhitelisted, "/", null, null, null)
         { TestDisplayName = "ForwardedIp_Enabled_Header_Absent_FallsBack_Returns_200" };
 
         // Header enabled + carries an invalid IP -> falls back to connection IP -> blocked.
-        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?>(
-            ForwardedIpEnabled, "/", "cf-connecting-ip", "not-an-ip")
+        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?, string?>(
+            ForwardedIpEnabled, "/", "cf-connecting-ip", "not-an-ip", null)
         { TestDisplayName = "ForwardedIp_Enabled_Invalid_Header_FallsBack_Returns_400" };
 
         // Custom (non-Cloudflare) header name is honoured -> allowed.
-        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?>(
-            ForwardedIpCustomHeader, "/", "X-Azure-ClientIP", "4.180.158.195")
+        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?, string?>(
+            ForwardedIpCustomHeader, "/", "X-Azure-ClientIP", "4.180.158.195", null)
         { TestDisplayName = "ForwardedIp_CustomHeader_Returns_200" };
+
+        // Trusted host matches the request host -> header honoured -> allowed.
+        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?, string?>(
+            ForwardedIpTrustedHost, "/", "cf-connecting-ip", "4.180.158.195", "www.example.com")
+        { TestDisplayName = "ForwardedIp_TrustedHost_Match_UsesHeader_Returns_200" };
+
+        // Request arrives on the raw (untrusted) domain -> header ignored, connection IP used -> blocked.
+        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?, string?>(
+            ForwardedIpTrustedHost, "/", "cf-connecting-ip", "4.180.158.195", "myproject.umbraco.io")
+        { TestDisplayName = "ForwardedIp_UntrustedHost_IgnoresHeader_Returns_400" };
     }
 
     private readonly RequestProtectOptions ForwardedIpEnabled = new()
@@ -86,6 +96,22 @@ public class OptionsWithForwardedIpTestCases : IEnumerable<TheoryDataRow<Request
         Code = "mya",
         QueryKey = "mya",
         ForwardedIp = new ForwardedIpSettings { Enabled = true, HeaderName = "X-Azure-ClientIP" },
+        Rules = new AuthRules()
+        {
+            IpWhitelist = ["4.180.158.192/28"]
+        }
+    };
+
+    private readonly RequestProtectOptions ForwardedIpTrustedHost = new()
+    {
+        Enabled = true,
+        Code = "mya",
+        QueryKey = "mya",
+        ForwardedIp = new ForwardedIpSettings
+        {
+            Enabled = true,
+            TrustedHosts = ["www.example.com"]
+        },
         Rules = new AuthRules()
         {
             IpWhitelist = ["4.180.158.192/28"]

--- a/src/MYA.RequestProtect.Test/TestCases/OptionsWithForwardedIpTestCases.cs
+++ b/src/MYA.RequestProtect.Test/TestCases/OptionsWithForwardedIpTestCases.cs
@@ -1,0 +1,96 @@
+using MYA.RequestProtect.Options;
+using System.Collections;
+
+namespace MYA.RequestProtect.Tests.TestCases;
+
+/// <summary>
+/// Test cases covering client IP resolution from a forwarded header (e.g. Cloudflare's
+/// "cf-connecting-ip") when hosted behind a trusted reverse proxy. Columns are
+/// (options, url, forwardedHeaderName, forwardedHeaderValue). The test harness always sets the
+/// transport connection IP to <see cref="Setup.Host.DefaultRemoteIP"/>.
+/// </summary>
+public class OptionsWithForwardedIpTestCases : IEnumerable<TheoryDataRow<RequestProtectOptions, string, string?, string?>>
+{
+    public IEnumerator<TheoryDataRow<RequestProtectOptions, string, string?, string?>> GetEnumerator()
+    {
+        // Header enabled + carries a whitelisted IP -> allowed, even though the connection IP is not whitelisted.
+        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?>(
+            ForwardedIpEnabled, "/", "cf-connecting-ip", "4.180.158.195")
+        { TestDisplayName = "ForwardedIp_Enabled_Whitelisted_Returns_200" };
+
+        // Header enabled + carries a non-whitelisted IP -> blocked.
+        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?>(
+            ForwardedIpEnabled, "/", "cf-connecting-ip", "8.8.8.8")
+        { TestDisplayName = "ForwardedIp_Enabled_NotWhitelisted_Returns_400" };
+
+        // Header disabled but a spoofed whitelisted IP is sent -> ignored, connection IP used -> blocked.
+        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?>(
+            ForwardedIpDisabled, "/", "cf-connecting-ip", "4.180.158.195")
+        { TestDisplayName = "ForwardedIp_Disabled_Header_Ignored_Returns_400" };
+
+        // Header enabled but absent -> falls back to the (whitelisted) connection IP -> allowed.
+        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?>(
+            ForwardedIpEnabledConnectionWhitelisted, "/", null, null)
+        { TestDisplayName = "ForwardedIp_Enabled_Header_Absent_FallsBack_Returns_200" };
+
+        // Header enabled + carries an invalid IP -> falls back to connection IP -> blocked.
+        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?>(
+            ForwardedIpEnabled, "/", "cf-connecting-ip", "not-an-ip")
+        { TestDisplayName = "ForwardedIp_Enabled_Invalid_Header_FallsBack_Returns_400" };
+
+        // Custom (non-Cloudflare) header name is honoured -> allowed.
+        yield return new TheoryDataRow<RequestProtectOptions, string, string?, string?>(
+            ForwardedIpCustomHeader, "/", "X-Azure-ClientIP", "4.180.158.195")
+        { TestDisplayName = "ForwardedIp_CustomHeader_Returns_200" };
+    }
+
+    private readonly RequestProtectOptions ForwardedIpEnabled = new()
+    {
+        Enabled = true,
+        Code = "mya",
+        QueryKey = "mya",
+        ForwardedIp = new ForwardedIpSettings { Enabled = true },
+        Rules = new AuthRules()
+        {
+            IpWhitelist = ["4.180.158.192/28"]
+        }
+    };
+
+    private readonly RequestProtectOptions ForwardedIpDisabled = new()
+    {
+        Enabled = true,
+        Code = "mya",
+        QueryKey = "mya",
+        ForwardedIp = new ForwardedIpSettings { Enabled = false },
+        Rules = new AuthRules()
+        {
+            IpWhitelist = ["4.180.158.192/28"]
+        }
+    };
+
+    private readonly RequestProtectOptions ForwardedIpEnabledConnectionWhitelisted = new()
+    {
+        Enabled = true,
+        Code = "mya",
+        QueryKey = "mya",
+        ForwardedIp = new ForwardedIpSettings { Enabled = true },
+        Rules = new AuthRules()
+        {
+            IpWhitelist = [Setup.Host.DefaultRemoteIP]
+        }
+    };
+
+    private readonly RequestProtectOptions ForwardedIpCustomHeader = new()
+    {
+        Enabled = true,
+        Code = "mya",
+        QueryKey = "mya",
+        ForwardedIp = new ForwardedIpSettings { Enabled = true, HeaderName = "X-Azure-ClientIP" },
+        Rules = new AuthRules()
+        {
+            IpWhitelist = ["4.180.158.192/28"]
+        }
+    };
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/MYA.RequestProtect/Options/ForwardedIpSettings.cs
+++ b/src/MYA.RequestProtect/Options/ForwardedIpSettings.cs
@@ -22,4 +22,13 @@ public class ForwardedIpSettings
     /// "X-Azure-ClientIP"). If the header carries a comma-separated list, the first entry is used.
     /// </summary>
     public string HeaderName { get; set; } = "cf-connecting-ip";
+
+    /// <summary>
+    /// Optional list of hostnames the forwarded header is trusted for (case-insensitive, exact match on the
+    /// request host without port). Use this where the application is reachable both via a proxied custom
+    /// domain and a non-proxied raw domain (e.g. Umbraco Cloud's *.umbraco.io) so the header is trusted only
+    /// on the proxied custom domain and ignored on the raw domain, where it could be spoofed. When null or
+    /// empty, the header is trusted on all hosts.
+    /// </summary>
+    public string[]? TrustedHosts { get; set; }
 }

--- a/src/MYA.RequestProtect/Options/ForwardedIpSettings.cs
+++ b/src/MYA.RequestProtect/Options/ForwardedIpSettings.cs
@@ -1,0 +1,25 @@
+namespace MYA.RequestProtect.Options;
+
+/// <summary>
+/// Configuration for resolving the client IP address from a forwarded header when the
+/// application is hosted behind a trusted reverse proxy or CDN (e.g. Cloudflare, Azure Front Door).
+/// </summary>
+public class ForwardedIpSettings
+{
+    public const string Key = $"{RequestProtectOptions.Key}:ForwardedIp";
+
+    /// <summary>
+    /// When true, the client IP is read from <see cref="HeaderName"/> before falling back to the
+    /// transport connection IP. Only enable this when the application is guaranteed to receive traffic
+    /// exclusively via the named trusted proxy; otherwise a client could spoof the header and bypass the
+    /// IP whitelist. Default: false.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Name of the header carrying the originating client IP address. Defaults to Cloudflare's
+    /// "cf-connecting-ip". Other proxies use different headers (e.g. Azure Front Door uses
+    /// "X-Azure-ClientIP"). If the header carries a comma-separated list, the first entry is used.
+    /// </summary>
+    public string HeaderName { get; set; } = "cf-connecting-ip";
+}

--- a/src/MYA.RequestProtect/Options/RequestProtectOptions.cs
+++ b/src/MYA.RequestProtect/Options/RequestProtectOptions.cs
@@ -36,6 +36,11 @@ public class RequestProtectOptions : IValidatableObject
     /// </summary>
     public CookieSettings Cookie { get; set; } = new();
 
+    /// <summary>
+    /// Configuration for resolving the client IP from a forwarded header when hosted behind a trusted proxy
+    /// </summary>
+    public ForwardedIpSettings ForwardedIp { get; set; } = new();
+
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
         var results = new List<ValidationResult>();

--- a/src/MYA.RequestProtect/RequestProtectMiddleware.cs
+++ b/src/MYA.RequestProtect/RequestProtectMiddleware.cs
@@ -285,7 +285,7 @@ public sealed class RequestProtectMiddleware
 
     private bool AuthNotNeeded(HttpContext context)
     {
-        if (config.Rules.IpWhitelist is not null && config.Rules.IpWhitelist.Length > 0 && IsIpAllowed(context.Connection.RemoteIpAddress))
+        if (config.Rules.IpWhitelist is not null && config.Rules.IpWhitelist.Length > 0 && IsIpAllowed(ResolveClientIp(context)))
         {
             return true;
         }
@@ -306,6 +306,41 @@ public sealed class RequestProtectMiddleware
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Resolves the client IP address, preferring a configured forwarded header (e.g. Cloudflare's
+    /// "cf-connecting-ip") when <see cref="ForwardedIpSettings.Enabled"/> is set, and falling back to the
+    /// transport connection IP otherwise. The header is only trusted when explicitly enabled to prevent
+    /// clients spoofing it to bypass the IP whitelist.
+    /// </summary>
+    private IPAddress? ResolveClientIp(HttpContext context)
+    {
+        var forwarded = config.ForwardedIp;
+
+        if (forwarded is { Enabled: true } && !string.IsNullOrWhiteSpace(forwarded.HeaderName)
+            && context.Request.Headers.TryGetValue(forwarded.HeaderName, out var headerValues))
+        {
+            var raw = headerValues.ToString();
+            if (!string.IsNullOrWhiteSpace(raw))
+            {
+                // cf-connecting-ip carries a single IP; X-Forwarded-For style headers carry a comma
+                // separated list where the originating client is the first entry.
+                var commaIndex = raw.IndexOf(',', StringComparison.Ordinal);
+                var candidate = commaIndex >= 0 ? raw.AsSpan(0, commaIndex) : raw.AsSpan();
+                candidate = candidate.Trim();
+
+                if (IPAddress.TryParse(candidate, out var forwardedIp))
+                {
+                    logger.LogDebug("Resolved client IP {ip} from forwarded header {header}", forwardedIp, forwarded.HeaderName);
+                    return forwardedIp;
+                }
+
+                logger.LogWarning("Forwarded header {header} present but could not be parsed as an IP address", forwarded.HeaderName);
+            }
+        }
+
+        return context.Connection.RemoteIpAddress;
     }
 
     private bool IsIpAllowed(IPAddress? remoteIp)

--- a/src/MYA.RequestProtect/RequestProtectMiddleware.cs
+++ b/src/MYA.RequestProtect/RequestProtectMiddleware.cs
@@ -311,36 +311,67 @@ public sealed class RequestProtectMiddleware
     /// <summary>
     /// Resolves the client IP address, preferring a configured forwarded header (e.g. Cloudflare's
     /// "cf-connecting-ip") when <see cref="ForwardedIpSettings.Enabled"/> is set, and falling back to the
-    /// transport connection IP otherwise. The header is only trusted when explicitly enabled to prevent
-    /// clients spoofing it to bypass the IP whitelist.
+    /// transport connection IP otherwise. The header is only trusted when explicitly enabled and, when
+    /// <see cref="ForwardedIpSettings.TrustedHosts"/> is configured, only for those hosts. This prevents
+    /// clients spoofing it (e.g. via a non-proxied raw domain) to bypass the IP whitelist.
     /// </summary>
     private IPAddress? ResolveClientIp(HttpContext context)
     {
         var forwarded = config.ForwardedIp;
 
-        if (forwarded is { Enabled: true } && !string.IsNullOrWhiteSpace(forwarded.HeaderName)
-            && context.Request.Headers.TryGetValue(forwarded.HeaderName, out var headerValues))
+        if (forwarded is { Enabled: true } && !string.IsNullOrWhiteSpace(forwarded.HeaderName))
         {
-            var raw = headerValues.ToString();
-            if (!string.IsNullOrWhiteSpace(raw))
+            if (!IsTrustedHost(context.Request.Host, forwarded.TrustedHosts))
             {
-                // cf-connecting-ip carries a single IP; X-Forwarded-For style headers carry a comma
-                // separated list where the originating client is the first entry.
-                var commaIndex = raw.IndexOf(',', StringComparison.Ordinal);
-                var candidate = commaIndex >= 0 ? raw.AsSpan(0, commaIndex) : raw.AsSpan();
-                candidate = candidate.Trim();
-
-                if (IPAddress.TryParse(candidate, out var forwardedIp))
+                logger.LogDebug("Forwarded header {header} ignored for untrusted host {host}", forwarded.HeaderName, context.Request.Host.Host);
+            }
+            else if (context.Request.Headers.TryGetValue(forwarded.HeaderName, out var headerValues))
+            {
+                var raw = headerValues.ToString();
+                if (!string.IsNullOrWhiteSpace(raw))
                 {
-                    logger.LogDebug("Resolved client IP {ip} from forwarded header {header}", forwardedIp, forwarded.HeaderName);
-                    return forwardedIp;
-                }
+                    // cf-connecting-ip carries a single IP; X-Forwarded-For style headers carry a comma
+                    // separated list where the originating client is the first entry.
+                    var commaIndex = raw.IndexOf(',', StringComparison.Ordinal);
+                    var candidate = commaIndex >= 0 ? raw.AsSpan(0, commaIndex) : raw.AsSpan();
+                    candidate = candidate.Trim();
 
-                logger.LogWarning("Forwarded header {header} present but could not be parsed as an IP address", forwarded.HeaderName);
+                    if (IPAddress.TryParse(candidate, out var forwardedIp))
+                    {
+                        logger.LogDebug("Resolved client IP {ip} from forwarded header {header}", forwardedIp, forwarded.HeaderName);
+                        return forwardedIp;
+                    }
+
+                    logger.LogWarning("Forwarded header {header} present but could not be parsed as an IP address", forwarded.HeaderName);
+                }
             }
         }
 
         return context.Connection.RemoteIpAddress;
+    }
+
+    /// <summary>
+    /// Determines whether the forwarded header should be trusted for the request host. When no trusted hosts
+    /// are configured the header is trusted on all hosts; otherwise only on a case-insensitive exact match of
+    /// the request host (without port).
+    /// </summary>
+    private static bool IsTrustedHost(HostString host, string[]? trustedHosts)
+    {
+        if (trustedHosts is not { Length: > 0 }) return true;
+
+        var requestHost = host.Host;
+        if (string.IsNullOrEmpty(requestHost)) return false;
+
+        foreach (var trusted in trustedHosts)
+        {
+            if (!string.IsNullOrWhiteSpace(trusted)
+                && string.Equals(trusted.Trim(), requestHost, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private bool IsIpAllowed(IPAddress? remoteIp)


### PR DESCRIPTION
## Summary

Fixes #14 — IP whitelisting failed behind reverse proxies / CDNs (Cloudflare, Umbraco Cloud) because the middleware resolved the client IP from `context.Connection.RemoteIpAddress`, which is the proxy's address rather than the visitor's.

## Changes

- **`ForwardedIpSettings`** (new options): opt-in `Enabled` + configurable `HeaderName` (default `cf-connecting-ip`), bound at `MYA:RP:ForwardedIp`.
- **Middleware** now resolves the client IP via `ResolveClientIp`, reading the configured header only when enabled and falling back to the connection IP when the header is absent or unparseable. Handles comma-separated (`X-Forwarded-For` style) values by taking the first entry.
- **Docs**: README section covering configuration and the trusted-proxy security caveat (opt-in, off by default; prefer proxy-set headers over client-appendable `X-Forwarded-For`).

## Security

The header is trusted only when explicitly enabled — enabling it when traffic can reach the origin directly would let a client spoof the header to bypass the whitelist. Documented accordingly.

## Tests

Six new snapshot test cases: enabled+whitelisted, enabled+not-whitelisted, disabled (spoof ignored), header absent (fallback), invalid header (fallback), and custom header name. All pass across net8/9/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)