### PR TITLE
Feature/umbraco 17 upgrade & Cookie option adjustments

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -290,7 +290,8 @@ Configure the authentication cookie that is set after successful validation:
       "Code": "secret123",
       "Cookie": {
         "ExpiryMinutes": 60,
-        "PersistCookie": true
+        "PersistCookie": true,
+        "SlidingExpiration": true
       }
     }
   }
@@ -301,6 +302,7 @@ Configure the authentication cookie that is set after successful validation:
 |--------|-------------|---------|
 | `ExpiryMinutes` | Cookie expiry duration in minutes (1–525,600) | `30` |
 | `PersistCookie` | When `true`, sets an explicit expiry (survives browser restart). When `false`, creates a session cookie (deleted on browser close). | `true` |
+| `SlidingExpiration` | When `true` (and `PersistCookie` is also `true`), resets the cookie's expiry to `now + ExpiryMinutes` on every request from an already-authenticated client, so an actively-browsing user is never logged out mid-session. No effect when `PersistCookie` is `false`. Note: this sets a `Set-Cookie` header on every authenticated response, which prevents response/output caching and CDN caching for that traffic. | `false` |
 
 ### Further Examples
 

--- a/.gitignore
+++ b/.gitignore
@@ -500,3 +500,5 @@ $RECYCLE.BIN/
 # Verify files
 *.received.*
 /src/MYA.RequestProtect/appsettings-schema.MYA.RequestProtect.json
+
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,11 @@ Options bind to the `MYA:RP` configuration section via `RequestProtectOptions`. 
 
 ### Performance
 
-The middleware pre-parses whitelist IPs and headers into struct arrays (`WhitelistEntry`, `HeaderEntry`) in the constructor. Regex patterns are cached in a `ConcurrentDictionary<string, Regex>`. Hot paths use `AggressiveInlining` and `Span`-based iteration.
+The middleware pre-parses whitelist IPs and headers into struct arrays (`WhitelistEntry`, `HeaderEntry`) and compiles regex patterns into a `FrozenDictionary<string, Regex>`. These, along with the bound options, are held in a single `CompiledConfig` snapshot swapped atomically via a `volatile` field whenever `IOptionsMonitor<RequestProtectOptions>` reports a config change (see Live Config Reload below) — not rebuilt per request. Hot paths use `AggressiveInlining` and `Span`-based iteration.
+
+### Live Config Reload
+
+`RequestProtectMiddleware` takes `IOptionsMonitor<RequestProtectOptions>` and re-compiles its `CompiledConfig` snapshot on every `OnChange` notification, so edits to `appsettings.json` (file reload) or environment variables take effect without an app restart. A config edit that fails to compile (e.g. an invalid regex `Pattern`) is logged and the previous good snapshot is kept rather than thrown from the reload callback. Each `config.X` read within a request reflects the latest snapshot at read time — not a snapshot fixed for the whole request — matching plain `IOptionsMonitor.CurrentValue` semantics. `MYA.RequestProtect.Umbraco.Bellissima`'s admin API controller also reads `IOptionsMonitor<RequestProtectOptions>.CurrentValue` per request so its display of enabled state, the auth query string, and current rules stays in sync with a live reload.
 
 ### Projects
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Rules use **inverted logic**: if any enabled rule matches the request, auth **is
 Options bind to the `MYA:RP` configuration section via `RequestProtectOptions`. Key nested types:
 - `AuthRules` - contains `IpWhitelist` (string[]), `Headers` (HeaderDetail[]), `Rules` (AuthRule[]), `RuleGroups` (AuthRuleGroup[]), `RulesOperator` (RuleGroupOperator)
 - `ResponseOptions` - controls unauthorized response behavior (Default 400, Redirect, or StaticFile with MimeType)
+- `CookieSettings` - controls the `MYAPA` auth cookie's `ExpiryMinutes`, whether it `PersistCookie` (persistent vs. session cookie), and optional `SlidingExpiration` (refreshes the cookie's expiry on every request from an already-authenticated client; no effect when `PersistCookie` is false)
 
 ### Performance
 

--- a/docs/README_nuget.md
+++ b/docs/README_nuget.md
@@ -11,6 +11,7 @@ A flexible and powerful ASP.NET Core middleware for protecting web requests thro
 - 🎯 URL pattern matching rules
 - 🍪 Automatic cookie-based authentication after successful validation
 - ⚙️ Highly configurable through appsettings.json
+- 🔄 Live config reload — changes to appsettings.json or environment variables take effect without an app restart
 - 📝 Comprehensive logging support
 
 ## Quick Start
@@ -46,6 +47,10 @@ app.UseMiddleware<RequestProtectMiddleware>();
   }
 }
 ```
+
+## Live Config Reload
+
+Config is bound via `IOptionsMonitor<RequestProtectOptions>`, so editing `appsettings.json` (or an environment variable, if your host reloads config from it) takes effect immediately — no restart required. If an edit produces invalid config (e.g. a bad regex `Pattern`), the error is logged and the middleware keeps running with its last valid configuration.
 
 ## Documentation
 

--- a/docs/README_nuget.md
+++ b/docs/README_nuget.md
@@ -65,7 +65,7 @@ app.UseMiddleware<RequestProtectMiddleware>();
 }
 ```
 
-With `SlidingExpiration: true`, an already-authenticated visitor's cookie expiry resets to `now + ExpiryMinutes` on every request, so an actively-browsing user is never logged out mid-session. Has no effect when `PersistCookie` is `false` (session cookies have no server-tracked expiry to extend).
+With `SlidingExpiration: true`, an already-authenticated visitor's cookie expiry resets to `now + ExpiryMinutes` on every request, so an actively-browsing user is never logged out mid-session. Has no effect when `PersistCookie` is `false` (session cookies have no server-tracked expiry to extend). Note: this sets a `Set-Cookie` header on every authenticated response, which prevents response/output caching and CDN caching for that traffic.
 
 ## Live Config Reload
 

--- a/docs/README_nuget.md
+++ b/docs/README_nuget.md
@@ -48,6 +48,25 @@ app.UseMiddleware<RequestProtectMiddleware>();
 }
 ```
 
+## Cookie Options
+
+```json
+{
+  "MYA:RP": {
+    "Enabled": true,
+    "QueryKey": "auth",
+    "Code": "your_secret_code",
+    "Cookie": {
+      "ExpiryMinutes": 30,
+      "PersistCookie": true,
+      "SlidingExpiration": true
+    }
+  }
+}
+```
+
+With `SlidingExpiration: true`, an already-authenticated visitor's cookie expiry resets to `now + ExpiryMinutes` on every request, so an actively-browsing user is never logged out mid-session. Has no effect when `PersistCookie` is `false` (session cookies have no server-tracked expiry to extend).
+
 ## Live Config Reload
 
 Config is bound via `IOptionsMonitor<RequestProtectOptions>`, so editing `appsettings.json` (or an environment variable, if your host reloads config from it) takes effect immediately — no restart required. If an edit produces invalid config (e.g. a bad regex `Pattern`), the error is logged and the middleware keeps running with its last valid configuration.

--- a/docs/README_umbraco_admin_nuget.md
+++ b/docs/README_umbraco_admin_nuget.md
@@ -7,6 +7,7 @@ Provides a simple admin dashboard for seeing the current configuration for Moriy
 - 🔒 Shows the enabled/disabled state
 - 🌐 If enabled, shows the query string component for easy copy/paste
 - ⚙️ Display the current rules configuration as loaded by the website.
+- 🔄 Reflects live config reloads — the dashboard always shows the currently active configuration, even after an appsettings.json edit without a restart.
 
 ## Installation
 

--- a/docs/README_umbraco_nuget.md
+++ b/docs/README_umbraco_nuget.md
@@ -11,6 +11,7 @@ Seamlessly integrate request protection into your Umbraco website. This package 
 - 🎯 Pattern matching for Umbraco URLs and routes
 - 🍪 Automatic cookie-based authentication after validation
 - ⚙️ Easy configuration through appsettings.json
+- 🔄 Live config reload — appsettings.json changes take effect without restarting the site
 - 📝 Integration with Umbraco's logging
 
 ## Installation

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -135,13 +135,14 @@ This example would redirect unauthorised requests to `https://example.com/unauth
       "Code": "My-Auth-Code",
       "Cookie": {
         "ExpiryMinutes": 60,
-        "PersistCookie": true
+        "PersistCookie": true,
+        "SlidingExpiration": true
       }
     }
   }
 }
 ```
-This example sets the authentication cookie to expire after 60 minutes. Set `PersistCookie` to `false` to create a session cookie that is deleted when the browser closes.
+This example sets the authentication cookie to expire after 60 minutes. Set `PersistCookie` to `false` to create a session cookie that is deleted when the browser closes. With `SlidingExpiration` set to `true`, the cookie's expiry resets on every request from an already-authenticated client, so an actively-browsing user is never logged out mid-session; this has no effect when `PersistCookie` is `false`, and note that it sets a `Set-Cookie` header on every authenticated response, which disables response/output/CDN caching for that traffic.
 
 ## Example 8: Hierarchical rule groups with All/Any operators
 ```json

--- a/docs/superpowers/plans/2026-07-31-live-config-reload.md
+++ b/docs/superpowers/plans/2026-07-31-live-config-reload.md
@@ -1,0 +1,424 @@
+# Live Config Reload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `RequestProtectMiddleware` picks up `appsettings.json`/environment-variable config changes live (via `IOptionsMonitor<RequestProtectOptions>.OnChange`) instead of only at process start.
+
+**Architecture:** Replace the middleware's one-time constructor snapshot (`RequestProtectOptions` field + precomputed regex/whitelist/header caches) with a single `CompiledConfig` object rebuilt on every `IOptionsMonitor.OnChange` notification and swapped into a `volatile` field. All existing option/cache reads are repointed at the current `CompiledConfig` via a compatibility property so most method bodies stay untouched. Test infrastructure gets a small reloadable `IConfigurationProvider` so tests can push a config change into a running `TestServer` and assert the middleware responds to the new rules without restarting the host.
+
+**Tech Stack:** ASP.NET Core middleware, `Microsoft.Extensions.Options` (`IOptionsMonitor`), `Microsoft.Extensions.Configuration` (custom `IConfigurationProvider` for tests), xUnit v3 + Verify (existing test stack).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-31-live-config-reload-design.md`
+- No per-request config snapshotting (rejected in spec) — each `config.X` read reflects the latest compiled snapshot at read time; this matches existing `IOptionsMonitor.CurrentValue` semantics and is accepted risk.
+- No `IDisposable` on the middleware — the `OnChange` registration lives for the app's lifetime, consistent with normal `IOptionsMonitor.OnChange` usage.
+- Existing static helpers `BuildRegexCache`, `ParseWhitelist`, `ParseHeaders` in `RequestProtectMiddleware.cs` are reused unchanged, just called from a new `Compile` method.
+- Existing tests (`MiddlewareShortCircuitTests`, `CookieConfigurationTests`, `ResponseTypeTests`, `AuthRulePolymorphismTests`, `LoggingValidationTests`) must continue to pass unchanged — the `Host.CreateTestServer` signature must not change for existing callers.
+
+---
+
+### Task 1: Compile config into a swappable snapshot in the middleware
+
+**Files:**
+- Modify: `src/MYA.RequestProtect/RequestProtectMiddleware.cs`
+
+**Interfaces:**
+- Produces: private nested `CompiledConfig` class with `Options` (`RequestProtectOptions`), `RegexCache` (`FrozenDictionary<string, Regex>`), `Whitelist` (`List<WhitelistEntry>`), `Headers` (`List<HeaderEntry>`) — all `required` init-only properties.
+- Produces: `private static CompiledConfig Compile(RequestProtectOptions options)` — pure function, no `this` access, callable from both the constructor and the `OnChange` callback.
+- Produces: `private volatile CompiledConfig _compiled` — current snapshot.
+- Produces: `private RequestProtectOptions config => _compiled.Options;` — replaces the old `config` field so all other existing method bodies (`InvokeAsync`, `AuthNotNeeded`, `ValidateCode`, `HandleUnAuthorisedRequest`, `HandleStaticFileResponse`, `HandleRedirectResponse`, `DefaultResponse`, `ResolveClientIp`) keep compiling with zero further edits.
+
+No new test file for this task — it's covered end-to-end by Task 3's tests. Existing tests must still pass (verified in Step 4 below) since this task preserves current behavior exactly; only the reload wiring is new.
+
+- [ ] **Step 1: Replace the constructor's snapshot fields with `CompiledConfig` + `Compile`**
+
+In `src/MYA.RequestProtect/RequestProtectMiddleware.cs`, remove these fields:
+
+```csharp
+private readonly RequestProtectOptions config;
+private readonly FrozenDictionary<string, Regex> _regexCache;
+private readonly List<WhitelistEntry> _parsedWhitelist;
+private readonly List<HeaderEntry> _parsedHeaders;
+```
+
+Replace with:
+
+```csharp
+private volatile CompiledConfig _compiled;
+
+private RequestProtectOptions config => _compiled.Options;
+
+private sealed class CompiledConfig
+{
+    public required RequestProtectOptions Options { get; init; }
+    public required FrozenDictionary<string, Regex> RegexCache { get; init; }
+    public required List<WhitelistEntry> Whitelist { get; init; }
+    public required List<HeaderEntry> Headers { get; init; }
+}
+
+private static CompiledConfig Compile(RequestProtectOptions options) => new()
+{
+    Options = options,
+    RegexCache = BuildRegexCache(options.Rules),
+    Whitelist = ParseWhitelist(options.Rules.IpWhitelist),
+    Headers = ParseHeaders(options.Rules.Headers)
+};
+```
+
+Update the constructor body from:
+
+```csharp
+this.config = config.CurrentValue;
+_next = next;
+this.logger = logger;
+this.dateTimeProvider = dateTimeProvider;
+this.hostingEnvironment = hostingEnvironment;
+_regexCache = BuildRegexCache(this.config.Rules);
+_parsedWhitelist = ParseWhitelist(this.config.Rules.IpWhitelist);
+_parsedHeaders = ParseHeaders(this.config.Rules.Headers);
+```
+
+to:
+
+```csharp
+_next = next;
+this.logger = logger;
+this.dateTimeProvider = dateTimeProvider;
+this.hostingEnvironment = hostingEnvironment;
+_compiled = Compile(config.CurrentValue);
+config.OnChange(newOptions => _compiled = Compile(newOptions));
+```
+
+(The constructor parameter is still named `config`, of type `IOptionsMonitor<RequestProtectOptions>` — it shadows the new `config` property inside the constructor only, same as it shadowed the old field before. No parameter rename needed.)
+
+- [ ] **Step 2: Repoint the three remaining direct cache-field usages**
+
+In `DoesRulePass`, change:
+
+```csharp
+if (!_regexCache.TryGetValue(r.Pattern, out var regex))
+```
+to:
+```csharp
+if (!_compiled.RegexCache.TryGetValue(r.Pattern, out var regex))
+```
+
+In `IsIpAllowed`, change:
+```csharp
+foreach (ref readonly var entry in CollectionsMarshal.AsSpan(_parsedWhitelist))
+```
+to:
+```csharp
+var whitelist = _compiled.Whitelist;
+foreach (ref readonly var entry in CollectionsMarshal.AsSpan(whitelist))
+```
+(local variable needed because `CollectionsMarshal.AsSpan` takes a `List<T>` argument, not an expression that re-reads a volatile field mid-iteration — reading `_compiled` once up front avoids observing two different snapshots inside a single loop.)
+
+In `HeadersAuthorised`, change:
+```csharp
+if (_parsedHeaders.Count == 0) return false;
+
+foreach (ref readonly var header in CollectionsMarshal.AsSpan(_parsedHeaders))
+```
+to:
+```csharp
+var headers = _compiled.Headers;
+if (headers.Count == 0) return false;
+
+foreach (ref readonly var header in CollectionsMarshal.AsSpan(headers))
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build src/MYA.RequestProtect/MYA.RequestProtect.csproj`
+Expected: builds with 0 errors across all three target frameworks (net8.0/net9.0/net10.0).
+
+- [ ] **Step 4: Run the full existing test suite to confirm no regression**
+
+Run: `dotnet test src/MYA.RequestProtect.Test/MYA.RequestProtect.Tests.csproj`
+Expected: all currently-passing tests still pass (this task is a behavior-preserving refactor).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/MYA.RequestProtect/RequestProtectMiddleware.cs
+git commit -m "refactor: compile options into swappable snapshot, wire OnChange
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Reloadable test configuration source
+
+**Files:**
+- Create: `src/MYA.RequestProtect.Test/Setup/ReloadableConfigurationSource.cs`
+- Modify: `src/MYA.RequestProtect.Test/Setup/Host.cs`
+
+**Interfaces:**
+- Consumes: `RequestProtectOptions.Key` (`"MYA:RP"`, from `src/MYA.RequestProtect/Options/RequestProtectOptions.cs:7`).
+- Produces: `internal sealed class ReloadableConfigurationProvider : ConfigurationProvider` with `public void Update(IDictionary<string, string?> newData)`.
+- Produces: `internal sealed class ReloadableConfigurationSource : IConfigurationSource` with `public ReloadableConfigurationProvider Provider { get; }`.
+- Produces: `Host.CreateTestServer(...)` (existing signature, unchanged) now also registers the `ReloadableConfigurationProvider` (when `options is not null`) as a singleton service, retrievable via `server.Services.GetRequiredService<ReloadableConfigurationProvider>()`, so tests can call `.Update(...)` on a live `TestServer` without any signature change.
+
+- [ ] **Step 1: Create `ReloadableConfigurationSource.cs`**
+
+```csharp
+using Microsoft.Extensions.Configuration;
+
+namespace MYA.RequestProtect.Tests.Setup;
+
+internal sealed class ReloadableConfigurationProvider : ConfigurationProvider
+{
+    public void Update(IDictionary<string, string?> newData)
+    {
+        Data = new Dictionary<string, string?>(newData, StringComparer.OrdinalIgnoreCase);
+        OnReload();
+    }
+}
+
+internal sealed class ReloadableConfigurationSource : IConfigurationSource
+{
+    public ReloadableConfigurationProvider Provider { get; } = new();
+
+    public IConfigurationProvider Build(IConfigurationBuilder builder) => Provider;
+}
+```
+
+- [ ] **Step 2: Wire it into `Host.CreateTestServer`**
+
+In `src/MYA.RequestProtect.Test/Setup/Host.cs`, add a `using System.Linq;` if not already present (needed for `.ToDictionary` below), then replace the `ConfigureAppConfiguration` block:
+
+```csharp
+.ConfigureAppConfiguration((context, config) =>
+{
+    if (options is not null)
+    {
+        var json = JsonSerializer.Serialize(new Dictionary<string, object?>
+        {
+            [RequestProtectOptions.Key] = options
+        });
+
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        config.AddJsonStream(stream);
+    }
+})
+```
+
+with:
+
+```csharp
+.ConfigureAppConfiguration((context, config) =>
+{
+    if (options is not null)
+    {
+        var source = new ReloadableConfigurationSource();
+        source.Provider.Update(FlattenOptions(options));
+        configProvider = source.Provider;
+        config.Add(source);
+    }
+})
+```
+
+Immediately before the `var builder = new WebHostBuilder()` line, declare:
+
+```csharp
+ReloadableConfigurationProvider? configProvider = null;
+```
+
+In the existing `.ConfigureServices(services => { ... })` block, add the registration after the existing two lines:
+
+```csharp
+services.RemoveAll<IDatetimeProvider>();
+services.AddSingleton<IDatetimeProvider, TestDatetimeProvider>();
+if (configProvider is not null)
+{
+    services.AddSingleton(configProvider);
+}
+```
+
+Add a private static helper at the bottom of the `Host` class (same file):
+
+```csharp
+private static Dictionary<string, string?> FlattenOptions(RequestProtectOptions options)
+{
+    var json = JsonSerializer.Serialize(new Dictionary<string, object?>
+    {
+        [RequestProtectOptions.Key] = options
+    });
+
+    using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+    var flat = new ConfigurationBuilder().AddJsonStream(stream).Build();
+    return flat.AsEnumerable().ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
+}
+```
+
+(`ConfigureAppConfiguration` runs during `WebHostBuilder.Build()` before `ConfigureServices` runs, so the captured `configProvider` local is already assigned by the time the `ConfigureServices` closure executes — both closures capture the same outer variable.)
+
+- [ ] **Step 3: Build and run full existing suite**
+
+Run: `dotnet build src/MYA.RequestProtect.Test/MYA.RequestProtect.Tests.csproj`
+Expected: builds with 0 errors.
+
+Run: `dotnet test src/MYA.RequestProtect.Test/MYA.RequestProtect.Tests.csproj`
+Expected: all existing tests still pass (the flattened-JSON config data is functionally equivalent to the old `AddJsonStream` binding — same JSON, just pre-flattened into key/value pairs before being handed to the config system).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/MYA.RequestProtect.Test/Setup/ReloadableConfigurationSource.cs src/MYA.RequestProtect.Test/Setup/Host.cs
+git commit -m "test: add reloadable configuration source for live-reload tests
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Live reload tests
+
+**Files:**
+- Create: `src/MYA.RequestProtect.Test/LiveConfigReloadTests.cs`
+
+**Interfaces:**
+- Consumes: `Host.CreateTestServer(logger, options)` (from Task 2), `server.Services.GetRequiredService<ReloadableConfigurationProvider>()`, `configProvider.Update(IDictionary<string,string?>)`.
+- Consumes: `RequestProtectOptions`, `AuthRules`, `AuthRule`, `AppliesTo` (existing, from `MYA.RequestProtect.Options`).
+
+This task's tests fail against Task 1's `main` branch state reverted (i.e. they'd fail against the pre-fix middleware) and pass once Task 1's fix is in place. Since Task 1 already landed by the time this task runs, Step 2 below is a sanity check by temporarily reverting — do this via inspection, not by literally reverting: read `RequestProtectMiddleware.cs` and confirm the `OnChange` wiring exists; if Step 4 (run tests) passes on the first try, that's the confirmation the fix works, so an actual revert-and-rerun is not required as a separate step.
+
+- [ ] **Step 1: Write the two failing-then-passing tests**
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using MYA.RequestProtect.Options;
+using MYA.RequestProtect.Tests.Extensions;
+using MYA.RequestProtect.Tests.Setup;
+
+namespace MYA.RequestProtect.Tests;
+
+public class LiveConfigReloadTests
+{
+    private readonly TestLogger logger = new();
+
+    private static RequestProtectOptions UnprotectedOptions => new()
+    {
+        Enabled = true,
+        Code = "valid_code",
+        Rules = new AuthRules()
+    };
+
+    private static RequestProtectOptions BlockAllOptions => new()
+    {
+        Enabled = true,
+        Code = "valid_code",
+        Rules = new AuthRules
+        {
+            Rules =
+            [
+                new()
+                {
+                    Name = "Block All",
+                    Pattern = ".*",
+                    Enabled = true,
+                    AppliesTo = AppliesTo.Path
+                }
+            ]
+        }
+    };
+
+    private static RequestProtectOptions WhitelistOptions(string ip) => new()
+    {
+        Enabled = true,
+        Code = "valid_code",
+        Rules = new AuthRules
+        {
+            IpWhitelist = [ip],
+            Rules =
+            [
+                new()
+                {
+                    Name = "Block All",
+                    Pattern = ".*",
+                    Enabled = true,
+                    AppliesTo = AppliesTo.Path
+                }
+            ]
+        }
+    };
+
+    [Fact]
+    public async Task RuleChange_ViaConfigReload_TakesEffectWithoutRestart()
+    {
+        // Arrange
+        using var server = Host.CreateTestServer(logger, UnprotectedOptions);
+        var client = server.CreateClient();
+
+        var before = await client.GetAsync("/admin/secret", TestContext.Current.CancellationToken);
+        Assert.Equal(System.Net.HttpStatusCode.OK, before.StatusCode);
+
+        // Act: push a new rule set that now blocks everything
+        var configProvider = server.Services.GetRequiredService<ReloadableConfigurationProvider>();
+        configProvider.Update(Host.FlattenOptionsForTest(BlockAllOptions));
+
+        var after = await client.GetAsync("/admin/secret", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, after.StatusCode);
+    }
+
+    [Fact]
+    public async Task WhitelistChange_ViaConfigReload_TakesEffectWithoutRestart()
+    {
+        // Arrange: whitelist a different IP than the test's remote IP, so the request is blocked
+        using var server = Host.CreateTestServer(logger, WhitelistOptions("198.51.100.1"));
+        var client = server.CreateClient();
+
+        var before = await client.GetAsync("/admin/secret", TestContext.Current.CancellationToken);
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, before.StatusCode);
+
+        // Act: push a config update that whitelists the test's actual remote IP
+        var configProvider = server.Services.GetRequiredService<ReloadableConfigurationProvider>();
+        configProvider.Update(Host.FlattenOptionsForTest(WhitelistOptions(Host.DefaultRemoteIP)));
+
+        var after = await client.GetAsync("/admin/secret", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(System.Net.HttpStatusCode.OK, after.StatusCode);
+    }
+}
+```
+
+Because the test needs to flatten a `RequestProtectOptions` the same way `Host` does internally, change `FlattenOptions` in `Host.cs` (Task 2, Step 2) from `private static` to `internal static` and rename it `FlattenOptionsForTest` for a clear public-to-tests name:
+
+```csharp
+internal static Dictionary<string, string?> FlattenOptionsForTest(RequestProtectOptions options)
+```
+
+(Update the one call site inside `Host.CreateTestServer` accordingly: `source.Provider.Update(FlattenOptionsForTest(options));`.)
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `dotnet test src/MYA.RequestProtect.Test/MYA.RequestProtect.Tests.csproj --filter "FullyQualifiedName~LiveConfigReloadTests"`
+Expected: PASS (Task 1's fix is already in place, so these pass immediately — they exist to pin the behavior going forward and guard against regression).
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `dotnet test src/MYA.RequestProtect.Test/MYA.RequestProtect.Tests.csproj`
+Expected: all tests pass, including the two new ones.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/MYA.RequestProtect.Test/LiveConfigReloadTests.cs src/MYA.RequestProtect.Test/Setup/Host.cs
+git commit -m "test: cover live config reload for rules and IP whitelist
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** `CompiledConfig`/`Compile`/`OnChange` wiring (Task 1) ✅, consistency model documented inline via the volatile snapshot read pattern (Task 1, Step 2) ✅, testing section from spec covered by Task 3 ✅, out-of-scope items (Umbraco projects, per-request snapshot) untouched ✅.
+- **Type consistency:** `CompiledConfig`, `Compile`, `_compiled`, `config` property names match between Task 1's description and step code. `ReloadableConfigurationProvider`/`ReloadableConfigurationSource`/`FlattenOptionsForTest` names match between Task 2 and Task 3.
+- **No placeholders:** all steps contain literal code, not descriptions.

--- a/docs/superpowers/plans/2026-07-31-sliding-cookie-expiration.md
+++ b/docs/superpowers/plans/2026-07-31-sliding-cookie-expiration.md
@@ -1,0 +1,394 @@
+# Sliding Cookie Expiration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in `CookieSettings.SlidingExpiration` option so an actively-browsing user's `MYAPA` auth cookie expiry is pushed forward on every request instead of lapsing at a fixed time from first issue.
+
+**Architecture:** Extract the existing inline cookie-issuing code in `RequestProtectMiddleware.InvokeAsync` into a private `SetAuthCookie(HttpContext, string value)` helper. Change `HasMiddlewareAuthCookie` to also return the existing cookie's value via `out`. When a valid cookie is present and `SlidingExpiration && PersistCookie` are both true, call `SetAuthCookie` with the existing cookie value to reissue it with a refreshed `Expires`. No new types, no new configuration surface beyond one boolean.
+
+**Tech Stack:** ASP.NET Core middleware, xUnit v3 + Verify snapshot testing (existing test stack).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-31-sliding-cookie-expiration-design.md`
+- `CookieSettings.SlidingExpiration` defaults to `false` — no behavior change for existing configs.
+- `SlidingExpiration: true` with `PersistCookie: false` is accepted but inert (session cookies have no `Expires` to extend) — not validated, not rejected, no exception.
+- No threshold/debounce logic — every request with sliding enabled and a valid cookie reissues `Set-Cookie` (rejected in spec as unnecessary complexity for this task).
+- Sliding-refresh reuses the cookie's *existing* value (read from the request) — it does not mint a new value. Only `Expires` changes.
+- Existing tests (`CookieConfigurationTests.cs` and the rest of the 96-test suite) must continue to pass unchanged.
+
+---
+
+### Task 1: Extract `SetAuthCookie` helper and add sliding refresh to `InvokeAsync`
+
+**Files:**
+- Modify: `src/MYA.RequestProtect/Options/CookieSettings.cs`
+- Modify: `src/MYA.RequestProtect/RequestProtectMiddleware.cs`
+
+**Interfaces:**
+- Produces: `CookieSettings.SlidingExpiration` (`bool`, default `false`).
+- Produces: `private void SetAuthCookie(HttpContext context, string value)` on `RequestProtectMiddleware` — builds the `CookieOptions` (`HttpOnly`, `SameSite=Strict`, `IsEssential`, `Secure`, conditional `Expires` when `config.Cookie.PersistCookie`) and appends the cookie via `context.Response.Cookies.Append(RequestProtectCookieName, value, cookieOpts)`.
+- Produces: `private static bool HasMiddlewareAuthCookie(HttpRequest request, out string cookieValue)` — replaces the existing single-arg overload; `cookieValue` is the cookie's raw string value when found (non-null, non-whitespace), or `string.Empty` when not found.
+
+No test file for this task alone — covered end-to-end by Task 2's new tests, and this task's Step 4 (full suite run) proves no regression on first-issue behavior.
+
+- [ ] **Step 1: Add `SlidingExpiration` to `CookieSettings`**
+
+In `src/MYA.RequestProtect/Options/CookieSettings.cs`, add after the existing `PersistCookie` property:
+
+```csharp
+/// <summary>
+/// When true, and PersistCookie is also true, the auth cookie's expiry is reset to
+/// now + ExpiryMinutes on every request that carries a valid cookie, keeping an
+/// actively-browsing user authenticated indefinitely. No effect when PersistCookie
+/// is false (session cookies carry no server-tracked expiry to extend).
+/// </summary>
+public bool SlidingExpiration { get; set; } = false;
+```
+
+The full file should read:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+
+namespace MYA.RequestProtect.Options;
+
+public class CookieSettings
+{
+    /// <summary>
+    /// Cookie expiry duration in minutes (default: 30)
+    /// </summary>
+    [Range(1, 525_600)]
+    public int ExpiryMinutes { get; set; } = 30;
+
+    /// <summary>
+    /// When true, sets an explicit Expires header on the cookie (survives browser restart).
+    /// When false, creates a session cookie (deleted on browser close).
+    /// </summary>
+    public bool PersistCookie { get; set; } = true;
+
+    /// <summary>
+    /// When true, and PersistCookie is also true, the auth cookie's expiry is reset to
+    /// now + ExpiryMinutes on every request that carries a valid cookie, keeping an
+    /// actively-browsing user authenticated indefinitely. No effect when PersistCookie
+    /// is false (session cookies carry no server-tracked expiry to extend).
+    /// </summary>
+    public bool SlidingExpiration { get; set; } = false;
+}
+```
+
+- [ ] **Step 2: Extract `SetAuthCookie` and change `HasMiddlewareAuthCookie` to an `out`-returning overload**
+
+In `src/MYA.RequestProtect/RequestProtectMiddleware.cs`, replace the current `InvokeAsync` method (lines 138-175):
+
+```csharp
+public async Task InvokeAsync(HttpContext context)
+{
+    if (!config.Enabled || HasMiddlewareAuthCookie(context.Request))
+    {
+        await _next(context);
+        return;
+    }
+
+    logger.LogAuthCookieNotFound();
+
+    if (RequestIsAuthorised(context, out var setCookie))
+    {
+        if (setCookie is true)
+        {
+            var cookieOpts = new CookieOptions
+            {
+                HttpOnly = true,
+                SameSite = SameSiteMode.Strict,
+                IsEssential = true,
+                Secure = true
+            };
+
+            if (config.Cookie.PersistCookie)
+            {
+                cookieOpts.Expires = dateTimeProvider.NowOffSet.AddMinutes(config.Cookie.ExpiryMinutes);
+            }
+
+            context.Response.Cookies.Append(RequestProtectCookieName, dateTimeProvider.Now.Ticks.ToString(), cookieOpts);
+        }
+    }
+    else
+    {
+        await HandleUnAuthorisedRequest(context);
+        return;
+    }
+
+    await _next(context);
+}
+```
+
+with:
+
+```csharp
+public async Task InvokeAsync(HttpContext context)
+{
+    if (!config.Enabled)
+    {
+        await _next(context);
+        return;
+    }
+
+    if (HasMiddlewareAuthCookie(context.Request, out var existingCookieValue))
+    {
+        if (config.Cookie.SlidingExpiration && config.Cookie.PersistCookie)
+        {
+            SetAuthCookie(context, existingCookieValue);
+        }
+
+        await _next(context);
+        return;
+    }
+
+    logger.LogAuthCookieNotFound();
+
+    if (RequestIsAuthorised(context, out var setCookie))
+    {
+        if (setCookie is true)
+        {
+            SetAuthCookie(context, dateTimeProvider.Now.Ticks.ToString());
+        }
+    }
+    else
+    {
+        await HandleUnAuthorisedRequest(context);
+        return;
+    }
+
+    await _next(context);
+}
+
+private void SetAuthCookie(HttpContext context, string value)
+{
+    var cookieOpts = new CookieOptions
+    {
+        HttpOnly = true,
+        SameSite = SameSiteMode.Strict,
+        IsEssential = true,
+        Secure = true
+    };
+
+    if (config.Cookie.PersistCookie)
+    {
+        cookieOpts.Expires = dateTimeProvider.NowOffSet.AddMinutes(config.Cookie.ExpiryMinutes);
+    }
+
+    context.Response.Cookies.Append(RequestProtectCookieName, value, cookieOpts);
+}
+```
+
+Then find the existing `HasMiddlewareAuthCookie` method (currently around line 481):
+
+```csharp
+private static bool HasMiddlewareAuthCookie(HttpRequest request)
+    => request.Cookies.TryGetValue(RequestProtectCookieName, out var cookieVal) && !string.IsNullOrWhiteSpace(cookieVal);
+```
+
+Replace it with the `out`-returning form:
+
+```csharp
+private static bool HasMiddlewareAuthCookie(HttpRequest request, out string cookieValue)
+{
+    var found = request.Cookies.TryGetValue(RequestProtectCookieName, out var cookieVal) && !string.IsNullOrWhiteSpace(cookieVal);
+    cookieValue = found ? cookieVal! : string.Empty;
+    return found;
+}
+```
+
+Search the file for any other call site of `HasMiddlewareAuthCookie(` besides the one in `InvokeAsync` you just updated — if any exist, update them to use the new `out`-returning signature too (discard the value with `out _` if the call site doesn't need it).
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build src/MYA.RequestProtect/MYA.RequestProtect.csproj`
+Expected: builds with 0 errors across net8.0/net9.0/net10.0.
+
+- [ ] **Step 4: Run the full existing test suite to confirm no regression**
+
+Run: `dotnet test src/MYA.RequestProtect.Test/MYA.RequestProtect.Tests.csproj`
+Expected: all 96 currently-passing tests still pass (default `SlidingExpiration = false` means the new `if (config.Cookie.SlidingExpiration && ...)` branch is never taken by any existing test, so first-issue and short-circuit behavior is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/MYA.RequestProtect/Options/CookieSettings.cs src/MYA.RequestProtect/RequestProtectMiddleware.cs
+git commit -m "feat: add opt-in sliding cookie expiration
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Sliding expiration tests
+
+**Files:**
+- Modify: `src/MYA.RequestProtect.Test/CookieConfigurationTests.cs`
+
+**Interfaces:**
+- Consumes: `Host.CreateTestServer(logger, options)` (existing, unchanged), `RequestProtectOptions`, `CookieSettings.SlidingExpiration` / `.PersistCookie` (Task 1).
+- Consumes: the existing `MYAPA` cookie name and cookie-request pattern already used elsewhere in this file's sibling tests (`MiddlewareShortCircuitTests.cs`): `request.Headers.Add("Cookie", "MYAPA=somevalue");`.
+
+- [ ] **Step 1: Write the three new tests**
+
+Add to `src/MYA.RequestProtect.Test/CookieConfigurationTests.cs`, inside the `CookieConfigurationTests` class, after the existing `ValidAuth_SessionCookie_ExpiryMinutesIgnored` test:
+
+```csharp
+[Fact]
+public async Task SlidingExpiration_Enabled_RefreshesCookieOnEachRequest()
+{
+    // Arrange
+    var options = BlockingOptions;
+    options.Cookie.SlidingExpiration = true;
+    options.Cookie.PersistCookie = true;
+
+    using var server = Host.CreateTestServer(logger, options);
+    var client = server.CreateClient();
+
+    var request = new HttpRequestMessage(HttpMethod.Get, "/admin/secret");
+    request.Headers.Add("Cookie", "MYAPA=somevalue");
+
+    // Act
+    var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+    // Assert
+    Assert.True(response.Headers.Contains("Set-Cookie"));
+    var setCookie = response.Headers.GetValues("Set-Cookie").Single();
+    Assert.Contains("MYAPA=somevalue", setCookie);
+    Assert.Contains("expires=", setCookie, StringComparison.OrdinalIgnoreCase);
+}
+
+[Fact]
+public async Task SlidingExpiration_Disabled_DoesNotRefreshCookie()
+{
+    // Arrange
+    var options = BlockingOptions;
+    options.Cookie.SlidingExpiration = false;
+    options.Cookie.PersistCookie = true;
+
+    using var server = Host.CreateTestServer(logger, options);
+    var client = server.CreateClient();
+
+    var request = new HttpRequestMessage(HttpMethod.Get, "/admin/secret");
+    request.Headers.Add("Cookie", "MYAPA=somevalue");
+
+    // Act
+    var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+    // Assert
+    Assert.False(response.Headers.Contains("Set-Cookie"));
+}
+
+[Fact]
+public async Task SlidingExpiration_Enabled_WithSessionCookie_DoesNotRefreshCookie()
+{
+    // Arrange
+    var options = BlockingOptions;
+    options.Cookie.SlidingExpiration = true;
+    options.Cookie.PersistCookie = false;
+
+    using var server = Host.CreateTestServer(logger, options);
+    var client = server.CreateClient();
+
+    var request = new HttpRequestMessage(HttpMethod.Get, "/admin/secret");
+    request.Headers.Add("Cookie", "MYAPA=somevalue");
+
+    // Act
+    var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+    // Assert
+    Assert.False(response.Headers.Contains("Set-Cookie"));
+}
+```
+
+Add `using System.Linq;` to the top of `CookieConfigurationTests.cs` if it is not already present (needed for `.Single()`); check the existing `using` block first since `ImplicitUsings` may already cover it — if `dotnet build` (Step 3 below) reports no error about `Single`, leave the usings as they are.
+
+- [ ] **Step 2: Run the three new tests**
+
+Run: `dotnet test src/MYA.RequestProtect.Test/MYA.RequestProtect.Tests.csproj --filter "FullyQualifiedName~SlidingExpiration"`
+Expected: PASS (Task 1's implementation is already in place).
+
+- [ ] **Step 3: Build and run the full suite**
+
+Run: `dotnet build src/MYA.RequestProtect.Test/MYA.RequestProtect.Tests.csproj`
+Expected: 0 errors.
+
+Run: `dotnet test src/MYA.RequestProtect.Test/MYA.RequestProtect.Tests.csproj`
+Expected: all tests pass (96 existing + 3 new = 99) across net8.0/net9.0/net10.0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/MYA.RequestProtect.Test/CookieConfigurationTests.cs
+git commit -m "test: cover sliding cookie expiration behavior
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Document the new option
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `docs/README_nuget.md`
+
+**Interfaces:**
+- Consumes: `CookieSettings.SlidingExpiration` (Task 1) — no new interfaces produced, documentation only.
+
+- [ ] **Step 1: Add a short note to `CLAUDE.md`**
+
+In `CLAUDE.md`, find the `### Configuration` section's bullet list (it currently ends with `- \`ResponseOptions\` - controls unauthorized response behavior (Default 400, Redirect, or StaticFile with MimeType)`). Add one line after it:
+
+```markdown
+- `CookieSettings` - controls the `MYAPA` auth cookie's `ExpiryMinutes`, whether it `PersistCookie` (persistent vs. session cookie), and optional `SlidingExpiration` (refreshes the cookie's expiry on every request from an already-authenticated client; no effect when `PersistCookie` is false)
+```
+
+- [ ] **Step 2: Add a config example to `docs/README_nuget.md`**
+
+In `docs/README_nuget.md`, after the existing "Quick Start" JSON example (the block ending `"Code": "your_secret_code"`), add a new subsection before `## Documentation`:
+
+```markdown
+## Cookie Options
+
+```json
+{
+  "MYA:RP": {
+    "Enabled": true,
+    "QueryKey": "auth",
+    "Code": "your_secret_code",
+    "Cookie": {
+      "ExpiryMinutes": 30,
+      "PersistCookie": true,
+      "SlidingExpiration": true
+    }
+  }
+}
+```
+
+With `SlidingExpiration: true`, an already-authenticated visitor's cookie expiry resets to `now + ExpiryMinutes` on every request, so an actively-browsing user is never logged out mid-session. Has no effect when `PersistCookie` is `false` (session cookies have no server-tracked expiry to extend).
+```
+
+- [ ] **Step 3: Verify no build/test impact**
+
+Run: `dotnet build src/MYA.RequestProtect.sln`
+Expected: 0 errors (documentation-only change, sanity check that nothing else broke).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md docs/README_nuget.md
+git commit -m "docs: document sliding cookie expiration option
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** `CookieSettings.SlidingExpiration` (Task 1) ✅, `SetAuthCookie` extraction + reissue on sliding (Task 1) ✅, `HasMiddlewareAuthCookie` out-value change (Task 1) ✅, inert-when-session-cookie behavior (Task 1's `&& config.Cookie.PersistCookie` guard) ✅, all three testing scenarios from the spec's Testing section (Task 2) ✅, existing cookie tests unaffected (Task 1 Step 4, Task 2 Step 3) ✅. Non-goals (no threshold/debounce, no `ExpiryMinutes` semantic change) are respected — no task introduces either.
+- **Type consistency:** `SetAuthCookie(HttpContext, string)`, `HasMiddlewareAuthCookie(HttpRequest, out string)` signatures match between Task 1's description and its code, and Task 2's tests only call through `Host.CreateTestServer`/HTTP, not these private members directly, so no cross-task signature drift risk.
+- **No placeholders:** all steps contain literal code, not descriptions.

--- a/docs/superpowers/specs/2026-07-31-live-config-reload-design.md
+++ b/docs/superpowers/specs/2026-07-31-live-config-reload-design.md
@@ -1,0 +1,63 @@
+# Live config reload for RequestProtectMiddleware
+
+## Problem
+
+`RequestProtectMiddleware` takes `IOptionsMonitor<RequestProtectOptions>` but reads `config.CurrentValue` once in the constructor into a readonly field. Derived caches (`_regexCache`, `_parsedWhitelist`, `_parsedHeaders`) are also built once in the constructor. Because ASP.NET Core constructs middleware once for the app lifetime, changes to `appsettings.json` (via the file-reload provider) or environment variables never take effect without an app restart.
+
+## Goal
+
+Config changes picked up by `IOptionsMonitor<RequestProtectOptions>` (file change, `IConfiguration` reload) must update middleware behavior — including rule/whitelist/header matching — without an app restart.
+
+## Design
+
+Introduce a private nested `CompiledConfig` holding everything currently derived from options once at startup:
+
+```csharp
+private sealed class CompiledConfig
+{
+    public required RequestProtectOptions Options { get; init; }
+    public required FrozenDictionary<string, Regex> RegexCache { get; init; }
+    public required List<WhitelistEntry> Whitelist { get; init; }
+    public required List<HeaderEntry> Headers { get; init; }
+}
+```
+
+A single `private static CompiledConfig Compile(RequestProtectOptions options)` method builds one from raw options (reusing existing `BuildRegexCache`, `ParseWhitelist`, `ParseHeaders` static helpers unchanged).
+
+Middleware holds:
+
+```csharp
+private volatile CompiledConfig _compiled;
+```
+
+Constructor:
+
+```csharp
+_compiled = Compile(monitor.CurrentValue);
+monitor.OnChange(o => _compiled = Compile(o));
+```
+
+Reference reassignment is atomic in .NET; `volatile` ensures visibility across threads without locking readers.
+
+All existing call sites (`config.Enabled`, `config.Rules...`, `_regexCache`, `_parsedWhitelist`, `_parsedHeaders`) are repointed at `_compiled`:
+
+- Existing private `config` field is removed; a private property `RequestProtectOptions config => _compiled.Options;` preserves nearly every existing call site's source text unchanged.
+- `_regexCache` → `_compiled.RegexCache`, `_parsedWhitelist` → `_compiled.Whitelist`, `_parsedHeaders` → `_compiled.Headers` (3 usage sites: `DoesRulePass`, `IsIpAllowed`, `HeadersAuthorised`).
+
+### Consistency model
+
+Each `config.X` read reflects the latest compiled snapshot at the moment of the read; a config reload mid-request could theoretically mix old/new values across multiple reads within one request. This matches the risk profile already inherent to `IOptionsMonitor.CurrentValue` and is accepted — not worth threading a per-request snapshot through ~10 private method signatures for a config that reloads rarely (deploy/ops time, not per-request).
+
+### Lifecycle
+
+No `IDisposable` implementation. The middleware instance lives for the app's lifetime; `OnChange` registration is not explicitly disposed (consistent with typical `IOptionsMonitor.OnChange` usage in ASP.NET Core apps where the callback lives as long as the app).
+
+## Testing
+
+- New test: build test host with initial `RequestProtectOptions`, assert baseline rule behavior, then push updated config through `IConfiguration` (test host's `TestServer` config reload or by re-binding `IOptionsMonitor` test double), assert middleware now matches the new rules/whitelist/headers without restarting the host.
+- Confirm existing snapshot tests still pass unchanged (no behavior change for the non-reload path).
+
+## Out of scope
+
+- Hot-reloading `MYA.RequestProtect.Umbraco` / `.Bellissima` integration wiring — they only register the middleware, no separate config snapshot logic to fix.
+- Per-request config snapshotting for strict consistency (rejected above).

--- a/docs/superpowers/specs/2026-07-31-sliding-cookie-expiration-design.md
+++ b/docs/superpowers/specs/2026-07-31-sliding-cookie-expiration-design.md
@@ -1,0 +1,121 @@
+# Sliding cookie expiration
+
+## Problem
+
+`RequestProtectMiddleware`'s auth cookie (`MYAPA`) is issued once, on successful query-string auth, with a fixed expiry (`now + Cookie.ExpiryMinutes`). Once a valid cookie exists, `InvokeAsync` short-circuits straight through to `_next(context)` (`RequestProtectMiddleware.cs:116-120`) without ever touching the cookie again. An actively-browsing user whose session outlives `ExpiryMinutes` gets logged out and must re-supply the query-string code, even though they never stopped using the site.
+
+## Goal
+
+Add an opt-in sliding expiration: while enabled, every request that carries a valid auth cookie has that cookie's expiry pushed forward to `now + ExpiryMinutes`, so an active user's cookie never lapses.
+
+## Design
+
+### `CookieSettings`
+
+New property, default `false` (opt-in, no behavior change for existing configs):
+
+```csharp
+/// <summary>
+/// When true, and PersistCookie is also true, the auth cookie's expiry is reset to
+/// now + ExpiryMinutes on every request that carries a valid cookie, keeping an
+/// actively-browsing user authenticated indefinitely. No effect when PersistCookie
+/// is false (session cookies carry no server-tracked expiry to extend).
+/// </summary>
+public bool SlidingExpiration { get; set; } = false;
+```
+
+### `RequestProtectMiddleware`
+
+Currently:
+
+```csharp
+public async Task InvokeAsync(HttpContext context)
+{
+    if (!config.Enabled || HasMiddlewareAuthCookie(context.Request))
+    {
+        await _next(context);
+        return;
+    }
+    ...
+```
+
+Change the short-circuit branch to refresh the cookie when sliding is enabled and a valid cookie is present:
+
+```csharp
+public async Task InvokeAsync(HttpContext context)
+{
+    if (!config.Enabled)
+    {
+        await _next(context);
+        return;
+    }
+
+    if (HasMiddlewareAuthCookie(context.Request, out var cookieValue))
+    {
+        if (config.Cookie.SlidingExpiration && config.Cookie.PersistCookie)
+        {
+            SetAuthCookie(context, cookieValue);
+        }
+
+        await _next(context);
+        return;
+    }
+    ...
+```
+
+`SetAuthCookie` is extracted from the existing cookie-issuing code in the `ValidateCode` success path (currently inlined in `InvokeAsync`, `RequestProtectMiddleware.cs:126-141`) into a private helper taking the cookie value to write, so both the first-issue path and the sliding-refresh path share one cookie-construction implementation:
+
+```csharp
+private void SetAuthCookie(HttpContext context, string value)
+{
+    var cookieOpts = new CookieOptions
+    {
+        HttpOnly = true,
+        SameSite = SameSiteMode.Strict,
+        IsEssential = true,
+        Secure = true
+    };
+
+    if (config.Cookie.PersistCookie)
+    {
+        cookieOpts.Expires = dateTimeProvider.NowOffSet.AddMinutes(config.Cookie.ExpiryMinutes);
+    }
+
+    context.Response.Cookies.Append(RequestProtectCookieName, value, cookieOpts);
+}
+```
+
+First-issue call site becomes `SetAuthCookie(context, dateTimeProvider.Now.Ticks.ToString());` (same value generation as today — unchanged).
+
+Sliding-refresh call site reuses the *existing* cookie value read from the request (`cookieValue`, from `HasMiddlewareAuthCookie`) rather than minting a new one — the cookie's identity value doesn't change on a slide, only its expiry.
+
+`HasMiddlewareAuthCookie` changes from:
+
+```csharp
+private static bool HasMiddlewareAuthCookie(HttpRequest request)
+    => request.Cookies.TryGetValue(RequestProtectCookieName, out var cookieVal) && !string.IsNullOrWhiteSpace(cookieVal);
+```
+
+to an overload-style signature that also returns the value, so the sliding path doesn't do a second cookie lookup:
+
+```csharp
+private static bool HasMiddlewareAuthCookie(HttpRequest request, out string cookieValue)
+{
+    var found = request.Cookies.TryGetValue(RequestProtectCookieName, out var cookieVal) && !string.IsNullOrWhiteSpace(cookieVal);
+    cookieValue = found ? cookieVal! : string.Empty;
+    return found;
+}
+```
+
+### Non-goals
+
+- No change to `ExpiryMinutes` semantics — it's still "minutes from last (re)issue," just now re-issued on every request when sliding is on, instead of only once.
+- No sliding when `PersistCookie` is `false` — session cookies have no `Expires` for the server to extend; `SlidingExpiration: true` with `PersistCookie: false` is accepted but inert, not validated/rejected.
+- No threshold/debounce logic (e.g. only reissue past 50% elapsed, as ASP.NET Core's own cookie auth does) — every request with sliding enabled reissues the `Set-Cookie` header. Simpler, matches user's explicit choice; a debounce can be added later if the extra header traffic becomes a real concern.
+
+## Testing
+
+- New test: sliding enabled + `PersistCookie: true` — request with a valid cookie gets a `Set-Cookie` response header with a fresh `Expires` value (assert response has `Set-Cookie`, not just that request passed through).
+- New test: sliding disabled (default) — request with a valid cookie passes through with no `Set-Cookie` header, confirming no behavior change from today.
+- New test: sliding enabled + `PersistCookie: false` — request with a valid cookie passes through with no `Set-Cookie` header (inert combination).
+- Existing cookie tests (`CookieConfigurationTests.cs`) must continue to pass unchanged — first-issue behavior is unaffected by this change.

--- a/src/MYA.RequestProtect.Test/CookieConfigurationTests.cs
+++ b/src/MYA.RequestProtect.Test/CookieConfigurationTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.Extensions.Options;
 using MYA.RequestProtect.Options;
 using MYA.RequestProtect.Tests.Setup;
@@ -106,5 +107,71 @@ public class CookieConfigurationTests
 
         // Assert
         await Verify(response);
+    }
+
+    [Fact]
+    public async Task SlidingExpiration_Enabled_RefreshesCookieOnEachRequest()
+    {
+        // Arrange
+        var options = BlockingOptions;
+        options.Cookie.SlidingExpiration = true;
+        options.Cookie.PersistCookie = true;
+
+        using var server = Host.CreateTestServer(logger, options);
+        var client = server.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/admin/secret");
+        request.Headers.Add("Cookie", "MYAPA=somevalue");
+
+        // Act
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(response.Headers.Contains("Set-Cookie"));
+        var setCookie = response.Headers.GetValues("Set-Cookie").Single();
+        Assert.Contains("MYAPA=somevalue", setCookie);
+        Assert.Contains("expires=", setCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SlidingExpiration_Disabled_DoesNotRefreshCookie()
+    {
+        // Arrange
+        var options = BlockingOptions;
+        options.Cookie.SlidingExpiration = false;
+        options.Cookie.PersistCookie = true;
+
+        using var server = Host.CreateTestServer(logger, options);
+        var client = server.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/admin/secret");
+        request.Headers.Add("Cookie", "MYAPA=somevalue");
+
+        // Act
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(response.Headers.Contains("Set-Cookie"));
+    }
+
+    [Fact]
+    public async Task SlidingExpiration_Enabled_WithSessionCookie_DoesNotRefreshCookie()
+    {
+        // Arrange
+        var options = BlockingOptions;
+        options.Cookie.SlidingExpiration = true;
+        options.Cookie.PersistCookie = false;
+
+        using var server = Host.CreateTestServer(logger, options);
+        var client = server.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/admin/secret");
+        request.Headers.Add("Cookie", "MYAPA=somevalue");
+
+        // Act
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(response.Headers.Contains("Set-Cookie"));
     }
 }

--- a/src/MYA.RequestProtect.Test/CookieConfigurationTests.cs
+++ b/src/MYA.RequestProtect.Test/CookieConfigurationTests.cs
@@ -116,6 +116,7 @@ public class CookieConfigurationTests
         var options = BlockingOptions;
         options.Cookie.SlidingExpiration = true;
         options.Cookie.PersistCookie = true;
+        options.Cookie.ExpiryMinutes = 45;
 
         using var server = Host.CreateTestServer(logger, options);
         var client = server.CreateClient();
@@ -130,7 +131,9 @@ public class CookieConfigurationTests
         Assert.True(response.Headers.Contains("Set-Cookie"));
         var setCookie = response.Headers.GetValues("Set-Cookie").Single();
         Assert.Contains("MYAPA=somevalue", setCookie);
-        Assert.Contains("expires=", setCookie, StringComparison.OrdinalIgnoreCase);
+        // TestDatetimeProvider is fixed at 2025-06-10 12:00:00 UTC; ExpiryMinutes=45 pins the exact
+        // refreshed expiry, so a slide-refresh that ignores ExpiryMinutes (e.g. hardcodes a value) fails this.
+        Assert.Contains("expires=Tue, 10 Jun 2025 12:45:00 GMT", setCookie, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/MYA.RequestProtect.Test/LiveConfigReloadTests.cs
+++ b/src/MYA.RequestProtect.Test/LiveConfigReloadTests.cs
@@ -1,0 +1,114 @@
+using Microsoft.Extensions.DependencyInjection;
+using MYA.RequestProtect.Options;
+using MYA.RequestProtect.Tests.Extensions;
+using MYA.RequestProtect.Tests.Setup;
+
+namespace MYA.RequestProtect.Tests;
+
+public class LiveConfigReloadTests
+{
+    private readonly TestLogger logger = new();
+
+    // NOTE: A completely empty AuthRules() (no rules, no groups, no whitelist, no headers) is
+    // treated as fully protected by RequestProtectMiddleware.AuthNotNeeded (it short-circuits to
+    // "auth needed" rather than evaluating an empty rule set as "nothing matched"). To exercise
+    // "unprotected because no configured rule matches this request" per the documented inverted-logic
+    // behavior, this uses one enabled rule that does not match the test path.
+    private static RequestProtectOptions UnprotectedOptions => new()
+    {
+        Enabled = true,
+        Code = "valid_code",
+        Rules = new AuthRules
+        {
+            Rules =
+            [
+                new()
+                {
+                    Name = "Does Not Match",
+                    Pattern = "^/never-matches$",
+                    Enabled = true,
+                    AppliesTo = AppliesTo.Path
+                }
+            ]
+        }
+    };
+
+    private static RequestProtectOptions BlockAllOptions => new()
+    {
+        Enabled = true,
+        Code = "valid_code",
+        Rules = new AuthRules
+        {
+            Rules =
+            [
+                new()
+                {
+                    Name = "Block All",
+                    Pattern = ".*",
+                    Enabled = true,
+                    AppliesTo = AppliesTo.Path
+                }
+            ]
+        }
+    };
+
+    private static RequestProtectOptions WhitelistOptions(string ip) => new()
+    {
+        Enabled = true,
+        Code = "valid_code",
+        Rules = new AuthRules
+        {
+            IpWhitelist = [ip],
+            Rules =
+            [
+                new()
+                {
+                    Name = "Block All",
+                    Pattern = ".*",
+                    Enabled = true,
+                    AppliesTo = AppliesTo.Path
+                }
+            ]
+        }
+    };
+
+    [Fact]
+    public async Task RuleChange_ViaConfigReload_TakesEffectWithoutRestart()
+    {
+        // Arrange
+        using var server = Host.CreateTestServer(logger, UnprotectedOptions);
+        var client = server.CreateClient();
+
+        var before = await client.GetAsync("/admin/secret", TestContext.Current.CancellationToken);
+        Assert.Equal(System.Net.HttpStatusCode.OK, before.StatusCode);
+
+        // Act: push a new rule set that now blocks everything
+        var configProvider = server.Services.GetRequiredService<ReloadableConfigurationProvider>();
+        configProvider.Update(Host.FlattenOptionsForTest(BlockAllOptions));
+
+        var after = await client.GetAsync("/admin/secret", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, after.StatusCode);
+    }
+
+    [Fact]
+    public async Task WhitelistChange_ViaConfigReload_TakesEffectWithoutRestart()
+    {
+        // Arrange: whitelist a different IP than the test's remote IP, so the request is blocked
+        using var server = Host.CreateTestServer(logger, WhitelistOptions("198.51.100.1"));
+        var client = server.CreateClient();
+
+        var before = await client.GetAsync("/admin/secret", TestContext.Current.CancellationToken);
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, before.StatusCode);
+
+        // Act: push a config update that whitelists the test's actual remote IP
+        var configProvider = server.Services.GetRequiredService<ReloadableConfigurationProvider>();
+        configProvider.Update(Host.FlattenOptionsForTest(WhitelistOptions(Host.DefaultRemoteIP)));
+
+        var after = await client.GetAsync("/admin/secret", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(System.Net.HttpStatusCode.OK, after.StatusCode);
+    }
+}

--- a/src/MYA.RequestProtect.Test/Setup/Host.cs
+++ b/src/MYA.RequestProtect.Test/Setup/Host.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using MYA.RequestProtect.Options;
 using MYA.RequestProtect.Setup;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -25,6 +26,8 @@ internal static class Host
         string? webRootPath = null, string? remoteIp = null,
         string? forwardedHeaderName = null, string? forwardedHeaderValue = null)
     {
+        ReloadableConfigurationProvider? configProvider = null;
+
         var builder = new WebHostBuilder()
             .UseTestServer();
 
@@ -38,13 +41,10 @@ internal static class Host
             {
                 if (options is not null)
                 {
-                    var json = JsonSerializer.Serialize(new Dictionary<string, object?>
-                    {
-                        [RequestProtectOptions.Key] = options
-                    });
-
-                    var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
-                    config.AddJsonStream(stream);
+                    var source = new ReloadableConfigurationSource();
+                    source.Provider.Update(FlattenOptions(options));
+                    configProvider = source.Provider;
+                    config.Add(source);
                 }
             })
             .ConfigureLogging(logging =>
@@ -61,6 +61,10 @@ internal static class Host
             {
                 services.RemoveAll<IDatetimeProvider>();
                 services.AddSingleton<IDatetimeProvider, TestDatetimeProvider>();
+                if (configProvider is not null)
+                {
+                    services.AddSingleton(configProvider);
+                }
             })
             .Configure(app =>
             {
@@ -94,5 +98,17 @@ internal static class Host
         {
             BaseAddress = baseAddress ?? new Uri("https://localhost/")
         };
+    }
+
+    private static Dictionary<string, string?> FlattenOptions(RequestProtectOptions options)
+    {
+        var json = JsonSerializer.Serialize(new Dictionary<string, object?>
+        {
+            [RequestProtectOptions.Key] = options
+        });
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var flat = new ConfigurationBuilder().AddJsonStream(stream).Build();
+        return flat.AsEnumerable().ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/MYA.RequestProtect.Test/Setup/Host.cs
+++ b/src/MYA.RequestProtect.Test/Setup/Host.cs
@@ -42,7 +42,7 @@ internal static class Host
                 if (options is not null)
                 {
                     var source = new ReloadableConfigurationSource();
-                    source.Provider.Update(FlattenOptions(options));
+                    source.Provider.Update(FlattenOptionsForTest(options));
                     configProvider = source.Provider;
                     config.Add(source);
                 }
@@ -100,7 +100,7 @@ internal static class Host
         };
     }
 
-    private static Dictionary<string, string?> FlattenOptions(RequestProtectOptions options)
+    internal static Dictionary<string, string?> FlattenOptionsForTest(RequestProtectOptions options)
     {
         var json = JsonSerializer.Serialize(new Dictionary<string, object?>
         {

--- a/src/MYA.RequestProtect.Test/Setup/ReloadableConfigurationSource.cs
+++ b/src/MYA.RequestProtect.Test/Setup/ReloadableConfigurationSource.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Configuration;
+
+namespace MYA.RequestProtect.Tests.Setup;
+
+internal sealed class ReloadableConfigurationProvider : ConfigurationProvider
+{
+    public void Update(IDictionary<string, string?> newData)
+    {
+        Data = new Dictionary<string, string?>(newData, StringComparer.OrdinalIgnoreCase);
+        OnReload();
+    }
+}
+
+internal sealed class ReloadableConfigurationSource : IConfigurationSource
+{
+    public ReloadableConfigurationProvider Provider { get; } = new();
+
+    public IConfigurationProvider Build(IConfigurationBuilder builder) => Provider;
+}

--- a/src/MYA.RequestProtect.Umbraco.Bellissima/Client/package-lock.json
+++ b/src/MYA.RequestProtect.Umbraco.Bellissima/Client/package-lock.json
@@ -14,18 +14,19 @@
         "chalk": "^5.4.1",
         "cross-env": "^7.0.3",
         "node-fetch": "^3.3.2",
-        "typescript": "^5.8.3",
-        "vite": "^6.3.4"
+        "typescript": "^5.9.3",
+        "vite": "^7.1.11"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
-      "integrity": "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -35,13 +36,14 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.8.tgz",
-      "integrity": "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -51,13 +53,14 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz",
-      "integrity": "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -67,13 +70,14 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.8.tgz",
-      "integrity": "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -83,13 +87,14 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz",
-      "integrity": "sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -99,13 +104,14 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz",
-      "integrity": "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -115,13 +121,14 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz",
-      "integrity": "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -131,13 +138,14 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz",
-      "integrity": "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -147,13 +155,14 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz",
-      "integrity": "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -163,13 +172,14 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz",
-      "integrity": "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -179,13 +189,14 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz",
-      "integrity": "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -195,13 +206,14 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz",
-      "integrity": "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -211,13 +223,14 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz",
-      "integrity": "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
       "cpu": [
         "mips64el"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -227,13 +240,14 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz",
-      "integrity": "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -243,13 +257,14 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz",
-      "integrity": "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -259,13 +274,14 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz",
-      "integrity": "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -275,13 +291,14 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
-      "integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -291,13 +308,14 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz",
-      "integrity": "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -307,13 +325,14 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz",
-      "integrity": "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -323,13 +342,14 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz",
-      "integrity": "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -339,13 +359,14 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz",
-      "integrity": "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -355,13 +376,14 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz",
-      "integrity": "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
@@ -371,13 +393,14 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz",
-      "integrity": "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -387,13 +410,14 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz",
-      "integrity": "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -403,13 +427,14 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz",
-      "integrity": "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -419,13 +444,14 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz",
-      "integrity": "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2618,11 +2644,12 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.8",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
-      "integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2630,32 +2657,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.8",
-        "@esbuild/android-arm": "0.25.8",
-        "@esbuild/android-arm64": "0.25.8",
-        "@esbuild/android-x64": "0.25.8",
-        "@esbuild/darwin-arm64": "0.25.8",
-        "@esbuild/darwin-x64": "0.25.8",
-        "@esbuild/freebsd-arm64": "0.25.8",
-        "@esbuild/freebsd-x64": "0.25.8",
-        "@esbuild/linux-arm": "0.25.8",
-        "@esbuild/linux-arm64": "0.25.8",
-        "@esbuild/linux-ia32": "0.25.8",
-        "@esbuild/linux-loong64": "0.25.8",
-        "@esbuild/linux-mips64el": "0.25.8",
-        "@esbuild/linux-ppc64": "0.25.8",
-        "@esbuild/linux-riscv64": "0.25.8",
-        "@esbuild/linux-s390x": "0.25.8",
-        "@esbuild/linux-x64": "0.25.8",
-        "@esbuild/netbsd-arm64": "0.25.8",
-        "@esbuild/netbsd-x64": "0.25.8",
-        "@esbuild/openbsd-arm64": "0.25.8",
-        "@esbuild/openbsd-x64": "0.25.8",
-        "@esbuild/openharmony-arm64": "0.25.8",
-        "@esbuild/sunos-x64": "0.25.8",
-        "@esbuild/win32-arm64": "0.25.8",
-        "@esbuild/win32-ia32": "0.25.8",
-        "@esbuild/win32-x64": "0.25.8"
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2672,10 +2699,14 @@
       }
     },
     "node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -3144,6 +3175,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -3561,13 +3593,14 @@
       "dev": true
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3584,10 +3617,11 @@
       "peer": true
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3637,23 +3671,24 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -3662,14 +3697,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@types/node": "^20.19.0 || >=22.12.0",
         "jiti": ">=1.21.0",
-        "less": "*",
+        "less": "^4.0.0",
         "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"

--- a/src/MYA.RequestProtect.Umbraco.Bellissima/Client/package.json
+++ b/src/MYA.RequestProtect.Umbraco.Bellissima/Client/package.json
@@ -15,7 +15,7 @@
     "chalk": "^5.4.1",
     "cross-env": "^7.0.3",
     "node-fetch": "^3.3.2",
-    "typescript": "^5.8.3",
-    "vite": "^6.3.4"
+    "typescript": "^5.9.3",
+    "vite": "^7.1.11"
   }
 }

--- a/src/MYA.RequestProtect.Umbraco.Bellissima/Client/tsconfig.json
+++ b/src/MYA.RequestProtect.Umbraco.Bellissima/Client/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "experimentalDecorators": true,
     "useDefineForClassFields": false,
     "module": "ESNext",
-    "lib": [ "ES2020", "DOM", "DOM.Iterable" ],
+    "lib": [ "ES2022", "DOM", "DOM.Iterable" ],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/src/MYA.RequestProtect.Umbraco.Bellissima/Composers/MYARequestProtectUmbracoAdminApiComposer.cs
+++ b/src/MYA.RequestProtect.Umbraco.Bellissima/Composers/MYARequestProtectUmbracoAdminApiComposer.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;

--- a/src/MYA.RequestProtect.Umbraco.Bellissima/Controllers/MYARequestProtectUmbracoAdminApiController.cs
+++ b/src/MYA.RequestProtect.Umbraco.Bellissima/Controllers/MYARequestProtectUmbracoAdminApiController.cs
@@ -14,12 +14,12 @@ namespace MYA.RequestProtect.Umbraco.Admin.Controllers
     [ApiExplorerSettings(GroupName = "MYA.RequestProtect.Umbraco.Admin")]
     public class MYARequestProtectUmbracoAdminApiController : MYARequestProtectUmbracoAdminApiControllerBase
     {
-        private RequestProtectOptions _config;
-        private IAuthorizationService _authorizationService;
+        private readonly IOptionsMonitor<RequestProtectOptions> _optionsMonitor;
+        private readonly IAuthorizationService _authorizationService;
 
-        public MYARequestProtectUmbracoAdminApiController(IOptions<RequestProtectOptions> options, IAuthorizationService authorizationService)
+        public MYARequestProtectUmbracoAdminApiController(IOptionsMonitor<RequestProtectOptions> optionsMonitor, IAuthorizationService authorizationService)
         {
-            _config = options.Value;
+            _optionsMonitor = optionsMonitor;
             _authorizationService = authorizationService;
         }
 
@@ -31,6 +31,8 @@ namespace MYA.RequestProtect.Umbraco.Admin.Controllers
         [ProducesResponseType<MyaRpEnabled>(StatusCodes.Status200OK)]
         public async Task<MyaRpEnabled> Enabled()
         {
+            var config = _optionsMonitor.CurrentValue;
+
             AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
             User,
             UserGroupPermissionResource.WithKeys(Guid.Parse(Constants.GroupGuid)),
@@ -38,8 +40,8 @@ namespace MYA.RequestProtect.Umbraco.Admin.Controllers
 
             var res = new MyaRpEnabled
             {
-                Enabled = _config.Enabled,
-                Code = authorizationResult.Succeeded && _config.Enabled ? $"{_config.QueryKey}={_config.Code}" : "---"
+                Enabled = config.Enabled,
+                Code = authorizationResult.Succeeded && config.Enabled ? $"{config.QueryKey}={config.Code}" : "---"
             };
 
             return res;
@@ -49,6 +51,8 @@ namespace MYA.RequestProtect.Umbraco.Admin.Controllers
         [ProducesResponseType<AuthRules>(StatusCodes.Status200OK)]
         public async Task<AuthRules?> GetProtectRules()
         {
+            var config = _optionsMonitor.CurrentValue;
+
             AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
             User,
             UserGroupPermissionResource.WithKeys(Guid.Parse(Constants.GroupGuid)),
@@ -59,7 +63,7 @@ namespace MYA.RequestProtect.Umbraco.Admin.Controllers
                 return null;
             }
 
-            return _config.Rules;
+            return config.Rules;
         }
 
         public class MyaRpEnabled

--- a/src/MYA.RequestProtect.Umbraco.Bellissima/MYA.RequestProtect.Umbraco.Bellissima.csproj
+++ b/src/MYA.RequestProtect.Umbraco.Bellissima/MYA.RequestProtect.Umbraco.Bellissima.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <StaticWebAssetBasePath>/</StaticWebAssetBasePath>
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-		<Version>16.1.0</Version>
-		<AssemblyVersion>16.1.0.0</AssemblyVersion>
-		<FileVersion>16.1.0.0</FileVersion>
+		<Version>17.0.0</Version>
+		<AssemblyVersion>17.0.0.0</AssemblyVersion>
+		<FileVersion>17.0.0.0</FileVersion>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Copyright>Copyright © Moriyama Limited $([System.DateTime]::Now.Year)</Copyright>
@@ -38,10 +38,10 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms.Web.Website" Version="16.0.0" />
-    <PackageReference Include="Umbraco.Cms.Web.Common" Version="16.0.0" />
-    <PackageReference Include="Umbraco.Cms.Api.Common" Version="16.0.0" />
-    <PackageReference Include="Umbraco.Cms.Api.Management" Version="16.0.0" />
+    <PackageReference Include="Umbraco.Cms.Web.Website" Version="17.0.0" />
+    <PackageReference Include="Umbraco.Cms.Web.Common" Version="17.0.0" />
+    <PackageReference Include="Umbraco.Cms.Api.Common" Version="17.0.0" />
+    <PackageReference Include="Umbraco.Cms.Api.Management" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MYA.RequestProtect.Umbraco/MYA.RequestProtect.Umbraco.csproj
+++ b/src/MYA.RequestProtect.Umbraco/MYA.RequestProtect.Umbraco.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<RootNamespace>MYA.RequestProtect.Umbraco</RootNamespace>
@@ -12,9 +12,9 @@
 
 	<PropertyGroup>
 		<PackageId>Moriyama.RequestProtect.Umbraco</PackageId>
-		<Version>1.3.2</Version>
-		<AssemblyVersion>1.3.2.0</AssemblyVersion>
-		<FileVersion>1.3.2.0</FileVersion>
+		<Version>2.0.0</Version>
+		<AssemblyVersion>2.0.0.0</AssemblyVersion>
+		<FileVersion>2.0.0.0</FileVersion>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Copyright>Copyright © Moriyama Limited $([System.DateTime]::Now.Year)</Copyright>
@@ -43,7 +43,14 @@
 		<PackageReference Include="Umbraco.Cms.Web.Common" Version="[16.0.0,17.0.0)" />
 	</ItemGroup>
 
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+	<!-- .NET 10.0 References -->
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+		<!-- Umbraco 17 -->
+		<PackageReference Include="Umbraco.Cms.Core" Version="[17.0.0,18.0.0)" />
+		<PackageReference Include="Umbraco.Cms.Web.Common" Version="[17.0.0,18.0.0)" />
+	</ItemGroup>
+
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net10.0' ">
         <StaticWebAssetBasePath>App_Plugins/Moriyama.RequestProtect</StaticWebAssetBasePath>
     </PropertyGroup>
 

--- a/src/MYA.RequestProtect.UmbracoTestSite/MYA.RequestProtect.UmbracoTestSite.csproj
+++ b/src/MYA.RequestProtect.UmbracoTestSite/MYA.RequestProtect.UmbracoTestSite.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <CompressionEnabled>false</CompressionEnabled> <!-- Disable compression. E.g. for umbraco backoffice files. These files should be precompressed by node and not let dotnet handle it -->
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms" Version="16.0.0" />
+    <PackageReference Include="Umbraco.Cms" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MYA.RequestProtect/Options/CookieSettings.cs
+++ b/src/MYA.RequestProtect/Options/CookieSettings.cs
@@ -15,4 +15,12 @@ public class CookieSettings
     /// When false, creates a session cookie (deleted on browser close).
     /// </summary>
     public bool PersistCookie { get; set; } = true;
+
+    /// <summary>
+    /// When true, and PersistCookie is also true, the auth cookie's expiry is reset to
+    /// now + ExpiryMinutes on every request that carries a valid cookie, keeping an
+    /// actively-browsing user authenticated indefinitely. No effect when PersistCookie
+    /// is false (session cookies carry no server-tracked expiry to extend).
+    /// </summary>
+    public bool SlidingExpiration { get; set; } = false;
 }

--- a/src/MYA.RequestProtect/RequestProtectMiddleware.cs
+++ b/src/MYA.RequestProtect/RequestProtectMiddleware.cs
@@ -51,7 +51,17 @@ public sealed class RequestProtectMiddleware
         this.dateTimeProvider = dateTimeProvider;
         this.hostingEnvironment = hostingEnvironment;
         _compiled = Compile(config.CurrentValue);
-        config.OnChange(newOptions => _compiled = Compile(newOptions));
+        config.OnChange(newOptions =>
+        {
+            try
+            {
+                _compiled = Compile(newOptions);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to compile reloaded RequestProtect configuration; keeping previous configuration");
+            }
+        });
     }
 
     private static List<HeaderEntry> ParseHeaders(HeaderDetail[]? headers)
@@ -299,7 +309,9 @@ public sealed class RequestProtectMiddleware
 
     private bool AuthNotNeeded(HttpContext context)
     {
-        if (config.Rules.IpWhitelist is not null && config.Rules.IpWhitelist.Length > 0 && IsIpAllowed(ResolveClientIp(context)))
+        var snapshot = _compiled;
+
+        if (snapshot.Options.Rules.IpWhitelist is not null && snapshot.Options.Rules.IpWhitelist.Length > 0 && IsIpAllowed(snapshot.Whitelist, ResolveClientIp(context)))
         {
             return true;
         }
@@ -309,13 +321,13 @@ public sealed class RequestProtectMiddleware
             return true;
         }
 
-        bool hasRules = config.Rules.Rules is { Length: > 0 };
-        bool hasGroups = config.Rules.RuleGroups is { Length: > 0 };
+        bool hasRules = snapshot.Options.Rules.Rules is { Length: > 0 };
+        bool hasGroups = snapshot.Options.Rules.RuleGroups is { Length: > 0 };
 
         if (hasRules || hasGroups)
         {
             bool matched = EvaluateRulesAndGroups(
-                config.Rules.Rules, config.Rules.RuleGroups, config.Rules.RulesOperator, context.Request);
+                snapshot.Options.Rules.Rules, snapshot.Options.Rules.RuleGroups, snapshot.Options.Rules.RulesOperator, context.Request);
             return !matched; // If matched -> auth IS needed
         }
 
@@ -388,11 +400,10 @@ public sealed class RequestProtectMiddleware
         return false;
     }
 
-    private bool IsIpAllowed(IPAddress? remoteIp)
+    private bool IsIpAllowed(List<WhitelistEntry> whitelist, IPAddress? remoteIp)
     {
         if (remoteIp is null) return false;
 
-        var whitelist = _compiled.Whitelist;
         foreach (ref readonly var entry in CollectionsMarshal.AsSpan(whitelist))
         {
             logger.LogDebug("Checking IP whitelist entry: {ip} against remote IP: {remoteIp}", entry.Pattern, remoteIp);

--- a/src/MYA.RequestProtect/RequestProtectMiddleware.cs
+++ b/src/MYA.RequestProtect/RequestProtectMiddleware.cs
@@ -137,8 +137,19 @@ public sealed class RequestProtectMiddleware
 
     public async Task InvokeAsync(HttpContext context)
     {
-        if (!config.Enabled || HasMiddlewareAuthCookie(context.Request))
+        if (!config.Enabled)
         {
+            await _next(context);
+            return;
+        }
+
+        if (HasMiddlewareAuthCookie(context.Request, out var existingCookieValue))
+        {
+            if (config.Cookie.SlidingExpiration && config.Cookie.PersistCookie)
+            {
+                SetAuthCookie(context, existingCookieValue);
+            }
+
             await _next(context);
             return;
         }
@@ -149,20 +160,7 @@ public sealed class RequestProtectMiddleware
         {
             if (setCookie is true)
             {
-                var cookieOpts = new CookieOptions
-                {
-                    HttpOnly = true,
-                    SameSite = SameSiteMode.Strict,
-                    IsEssential = true,
-                    Secure = true
-                };
-
-                if (config.Cookie.PersistCookie)
-                {
-                    cookieOpts.Expires = dateTimeProvider.NowOffSet.AddMinutes(config.Cookie.ExpiryMinutes);
-                }
-
-                context.Response.Cookies.Append(RequestProtectCookieName, dateTimeProvider.Now.Ticks.ToString(), cookieOpts);
+                SetAuthCookie(context, dateTimeProvider.Now.Ticks.ToString());
             }
         }
         else
@@ -172,6 +170,24 @@ public sealed class RequestProtectMiddleware
         }
 
         await _next(context);
+    }
+
+    private void SetAuthCookie(HttpContext context, string value)
+    {
+        var cookieOpts = new CookieOptions
+        {
+            HttpOnly = true,
+            SameSite = SameSiteMode.Strict,
+            IsEssential = true,
+            Secure = true
+        };
+
+        if (config.Cookie.PersistCookie)
+        {
+            cookieOpts.Expires = dateTimeProvider.NowOffSet.AddMinutes(config.Cookie.ExpiryMinutes);
+        }
+
+        context.Response.Cookies.Append(RequestProtectCookieName, value, cookieOpts);
     }
 
     private async Task HandleUnAuthorisedRequest(HttpContext context)
@@ -478,8 +494,12 @@ public sealed class RequestProtectMiddleware
         return ruleResult;
     }
 
-    private static bool HasMiddlewareAuthCookie(HttpRequest request)
-        => request.Cookies.TryGetValue(RequestProtectCookieName, out var cookieVal) && !string.IsNullOrWhiteSpace(cookieVal);
+    private static bool HasMiddlewareAuthCookie(HttpRequest request, out string cookieValue)
+    {
+        var found = request.Cookies.TryGetValue(RequestProtectCookieName, out var cookieVal) && !string.IsNullOrWhiteSpace(cookieVal);
+        cookieValue = found ? cookieVal! : string.Empty;
+        return found;
+    }
 
     private bool HeadersAuthorised(HttpContext context)
     {

--- a/src/MYA.RequestProtect/RequestProtectMiddleware.cs
+++ b/src/MYA.RequestProtect/RequestProtectMiddleware.cs
@@ -14,15 +14,31 @@ namespace MYA.RequestProtect;
 
 public sealed class RequestProtectMiddleware
 {
-    private readonly RequestProtectOptions config;
+    private volatile CompiledConfig _compiled;
+
+    private RequestProtectOptions config => _compiled.Options;
+
+    private sealed class CompiledConfig
+    {
+        public required RequestProtectOptions Options { get; init; }
+        public required FrozenDictionary<string, Regex> RegexCache { get; init; }
+        public required List<WhitelistEntry> Whitelist { get; init; }
+        public required List<HeaderEntry> Headers { get; init; }
+    }
+
+    private static CompiledConfig Compile(RequestProtectOptions options) => new()
+    {
+        Options = options,
+        RegexCache = BuildRegexCache(options.Rules),
+        Whitelist = ParseWhitelist(options.Rules.IpWhitelist),
+        Headers = ParseHeaders(options.Rules.Headers)
+    };
+
     private readonly RequestDelegate _next;
     private readonly ILogger logger;
     private readonly IDatetimeProvider dateTimeProvider;
     private readonly IWebHostEnvironment hostingEnvironment;
     private const string RequestProtectCookieName = "MYAPA";
-    private readonly FrozenDictionary<string, Regex> _regexCache;
-    private readonly List<WhitelistEntry> _parsedWhitelist;
-    private readonly List<HeaderEntry> _parsedHeaders;
 
     public RequestProtectMiddleware(RequestDelegate next,
         ILogger<RequestProtectMiddleware> logger,
@@ -30,14 +46,12 @@ public sealed class RequestProtectMiddleware
         IDatetimeProvider dateTimeProvider,
     IWebHostEnvironment hostingEnvironment)
     {
-        this.config = config.CurrentValue;
         _next = next;
         this.logger = logger;
         this.dateTimeProvider = dateTimeProvider;
         this.hostingEnvironment = hostingEnvironment;
-        _regexCache = BuildRegexCache(this.config.Rules);
-        _parsedWhitelist = ParseWhitelist(this.config.Rules.IpWhitelist);
-        _parsedHeaders = ParseHeaders(this.config.Rules.Headers);
+        _compiled = Compile(config.CurrentValue);
+        config.OnChange(newOptions => _compiled = Compile(newOptions));
     }
 
     private static List<HeaderEntry> ParseHeaders(HeaderDetail[]? headers)
@@ -378,7 +392,8 @@ public sealed class RequestProtectMiddleware
     {
         if (remoteIp is null) return false;
 
-        foreach (ref readonly var entry in CollectionsMarshal.AsSpan(_parsedWhitelist))
+        var whitelist = _compiled.Whitelist;
+        foreach (ref readonly var entry in CollectionsMarshal.AsSpan(whitelist))
         {
             logger.LogDebug("Checking IP whitelist entry: {ip} against remote IP: {remoteIp}", entry.Pattern, remoteIp);
             if (entry.Matches(remoteIp)) return true;
@@ -423,7 +438,7 @@ public sealed class RequestProtectMiddleware
 
     private bool DoesRulePass(AuthRule r, HttpRequest request)
     {
-        if (!_regexCache.TryGetValue(r.Pattern, out var regex))
+        if (!_compiled.RegexCache.TryGetValue(r.Pattern, out var regex))
         {
             regex = new Regex(r.Pattern, RegexOptions.Compiled | RegexOptions.CultureInvariant);
         }
@@ -457,9 +472,10 @@ public sealed class RequestProtectMiddleware
 
     private bool HeadersAuthorised(HttpContext context)
     {
-        if (_parsedHeaders.Count == 0) return false;
+        var headers = _compiled.Headers;
+        if (headers.Count == 0) return false;
 
-        foreach (ref readonly var header in CollectionsMarshal.AsSpan(_parsedHeaders))
+        foreach (ref readonly var header in CollectionsMarshal.AsSpan(headers))
         {
             if (header.Matches(context.Request.Headers)) return true;
         }


### PR DESCRIPTION
Official merge of Umbraco 17 upgrade branch to clean up branches and repos.

Adds ability to set auth cookie as sliding expiration
Makes Options monitoring effective so it doesn't require a site restart.